### PR TITLE
Add refactor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ If you find Logto helpful, here's how you can support us:
 - 🙋 [Open an issue](https://github.com/logto-io/logto/issues/new) to report bugs or suggest features.
 - 💻 [Contribute to Logto](https://github.com/logto-io/logto/blob/master/.github/CONTRIBUTING.md) - we'd love your help! Check out [Logto awesome](https://github.com/logto-io/logto/blob/master/AWESOME.md) of community-contributed resources.
 
+## Refactor Notes
+
+- [Tenant usage refactor](./docs-ref/tenant-usage-refactor.md)
+- [WebAuthn utils refactor](./docs-ref/webauthn-refactor.md)
+- [Verification records refactor](./docs-ref/verification-records-refactor.md)
+
+
 ## Licensing
 
 [MPL-2.0](LICENSE).

--- a/docs-ref/tenant-usage-refactor.md
+++ b/docs-ref/tenant-usage-refactor.md
@@ -1,0 +1,17 @@
+# Tenant Usage Refactor
+
+**File paths**
+- `packages/core/src/libraries/quota.ts`
+- `packages/core/src/queries/tenant-usage/index.ts`
+- `packages/core/src/tenants/Libraries.ts`
+- `packages/core/src/tenants/Queries.ts`
+- `packages/core/src/test-utils/quota.ts`
+
+**Key changes**
+- Injected the shared `Queries` object into `QuotaLibrary` instead of creating a `TenantUsageQuery` with `CommonQueryMethods`.
+- Updated `TenantUsageQuery` methods to accept a tenant id parameter and return tenant specific data.
+- Updated usages across tenant libraries and tests to use the new query interface.
+- Removed direct dependency on `CommonQueryMethods` from `QuotaLibrary`.
+
+**New dependencies / environment variables**
+- None.

--- a/docs-ref/verification-records-refactor.md
+++ b/docs-ref/verification-records-refactor.md
@@ -1,0 +1,14 @@
+# Verification Records Refactor
+
+**File paths**
+- `packages/core/src/routes/experience/classes/verifications/*`
+- `packages/core/src/routes/experience/types.ts`
+- `packages/schemas/src/types/verification-records/*`
+
+**Key changes**
+- Moved all verification record type definitions to `@logto/schemas` so they can be shared across packages.
+- Updated verification classes to import these types from `@logto/schemas` and removed their local `zod` schema definitions.
+- Added new type files under `packages/schemas/src/types/verification-records` and adjusted exports.
+
+**New dependencies / environment variables**
+- None.

--- a/docs-ref/webauthn-refactor.md
+++ b/docs-ref/webauthn-refactor.md
@@ -1,0 +1,12 @@
+# WebAuthn Utils Refactor
+
+**File paths**
+- `packages/core/src/routes/interaction/utils/webauthn.ts`
+- `packages/integration-tests/src/tests/api/account/mfa.test.ts`
+
+**Key changes**
+- Wrapped `verifyRegistrationResponse` in a `try/catch` block to surface errors as `RequestError` with code `session.mfa.webauthn_verification_failed` and status `400`.
+- Updated integration test to expect the new error code and status instead of a generic 500 response.
+
+**New dependencies / environment variables**
+- None.


### PR DESCRIPTION
## Summary
- add `docs-ref` directory
- document quota and tenant usage refactor
- document webauthn utilities refactor
- document verification records refactor
- link these docs from README

## Testing
- `pnpm -r test:ci --if-present` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3660dc24832f832deb47a00ec77f