### PR TITLE
Fix CI test pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,9 @@ jobs:
           pnpm-version: 9
           node-version: ^22.14.0
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Build for test
         run: pnpm -r build:test
 

--- a/.github/workflows/master-codecov-report.yml
+++ b/.github/workflows/master-codecov-report.yml
@@ -19,6 +19,9 @@ jobs:
           pnpm-version: 9
           node-version: ^22.14.0
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Install playwright for element tests
         working-directory: ./packages/elements
         run: pnpm exec playwright install --with-deps

--- a/packages/connectors/templates/package.json
+++ b/packages/connectors/templates/package.json
@@ -24,6 +24,10 @@
   "engines": {
     "node": "^22.14.0"
   },
+  "devDependencies": {
+    "vitest": "^3.1.1",
+    "@vitest/coverage-v8": "^3.1.1"
+  },
   "eslintConfig": {
     "extends": "@silverhand",
     "settings": {


### PR DESCRIPTION
## Summary
- ensure all template packages depend on vitest
- install dependencies in test workflows before running ci:test

## Testing
- `pnpm install` *(fails: forbidden)*
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3490d370832fa8b5f764860efcc0