### PR TITLE
Update local stack to MongoDB, OpenSearch and Redis

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -66,7 +66,7 @@ You'll need these installed to proceed:
 
 - [Node.js](https://nodejs.org/) `^18.12.0`
 - [pnpm](https://pnpm.io/) `^9.0`
-- A [Postgres](https://postgresql.org/) `^14.0` instance
+- A local MongoDB replica set, OpenSearch, and Redis instance (see `docker-compose.yml`)
 
 ### Clone and install dependencies
 
@@ -78,15 +78,15 @@ pnpm i && pnpm prepack
 
 `pnpm i` installs dependencies, which might take some time, and `pnpm prepack` builds the necessary workspace dependencies, enabling editors such as VSCode to locate their declarations.
 
-### Set up database
+### Configure services
 
-Create a `.env` file with the following content in the project root, or set the environment variable directly:
+Create a `.env` file with the following content in the project root, or set the environment variables directly:
 
 ```env
-DB_URL=postgresql://your-postgres-dsn/logto # Replace with your own
+MONGODB_URI=mongodb://localhost:27017/?replicaSet=rs0
+OPENSEARCH_URL=http://localhost:9200
+REDIS_URL=redis://localhost:6379
 ```
-
-Then run `pnpm cli db seed` to seed data into your database.
 
 ### Database alteration
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,18 @@
 tasks:
-  - name: Database
-    init: docker pull postgres:14-alpine
-    command: docker run -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=p0stgr3s postgres:14-alpine
+  - name: Services
+    init: |
+      docker pull mongo:7
+      docker pull opensearchproject/opensearch:2
+      docker pull redis:7-alpine
+    command: |
+      docker run -d --name mongodb -p 27017:27017 mongo:7 mongod --replSet rs0 --bind_ip_all
+      sleep 5
+      docker exec mongodb mongosh --eval "rs.initiate()"
+      docker run -d --name opensearch -p 9200:9200 \
+        -e discovery.type=single-node \
+        -e plugins.security.disabled=true \
+        opensearchproject/opensearch:2
+      docker run -d --name redis -p 6379:6379 redis:7-alpine
 
   - name: Logto dev
     init: |
@@ -15,15 +26,18 @@ tasks:
       pnpm connectors build
       pnpm cli connector link
     command: |
-      gp ports await 5432
+      gp ports await 27017
+      gp ports await 9200
+      gp ports await 6379
       sleep 3
       export ENDPOINT=$(gp url 3001)
       export ADMIN_ENDPOINT=$(gp url 3002)
-      pnpm cli db seed
       pnpm start:dev
     env:
       TRUST_PROXY_HEADER: 1
-      DB_URL: postgres://postgres:p0stgr3s@127.0.0.1:5432/logto
+      MONGODB_URI: mongodb://127.0.0.1:27017/?replicaSet=rs0
+      OPENSEARCH_URL: http://127.0.0.1:9200
+      REDIS_URL: redis://127.0.0.1:6379
 
 ports:
   - name: Logto
@@ -34,8 +48,16 @@ ports:
     description: The Admin Console for Logto core service
     port: 3002
     visibility: public
-  - name: Postgres
-    port: 5432
+  - name: MongoDB
+    port: 27017
+    visibility: public
+    onOpen: ignore
+  - name: OpenSearch
+    port: 9200
+    visibility: public
+    onOpen: ignore
+  - name: Redis
+    port: 6379
     visibility: public
     onOpen: ignore
   - port: 5001

--- a/README.md
+++ b/README.md
@@ -59,11 +59,15 @@ Pick your path:
 - **Local development:**  
 
   ```bash
-  # Using Docker Compose(requires Docker Desktop)
-  curl -fsSL https://raw.githubusercontent.com/logto-io/logto/HEAD/docker-compose.yml | \
-  docker compose -p logto -f - up
-  
-  # Using Node.js (requires PostgreSQL)
+  # Using Docker Compose (requires Docker Desktop)
+  docker compose up
+
+  # The services are available on the following URLs:
+  # MongoDB: mongodb://localhost:27017/?replicaSet=rs0
+  # OpenSearch: http://localhost:9200
+  # Redis: redis://localhost:6379
+
+  # Using Node.js
   npm init @logto
   ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,28 +3,57 @@ version: "3.9"
 services:
   app:
     depends_on:
-      postgres:
-        condition: service_healthy
+      mongodb-setup:
+        condition: service_completed_successfully
+      opensearch:
+        condition: service_started
+      redis:
+        condition: service_started
     image: svhd/logto:${TAG-latest}
-    entrypoint: ["sh", "-c", "npm run cli db seed -- --swe && npm start"]
+    entrypoint: ["sh", "-c", "npm start"]
     ports:
       - 3001:3001
       - 3002:3002
     environment:
       - TRUST_PROXY_HEADER=1
-      - DB_URL=postgres://postgres:p0stgr3s@postgres:5432/logto
+      - MONGODB_URI=mongodb://mongodb:27017/?replicaSet=rs0
+      - OPENSEARCH_URL=http://opensearch:9200
+      - REDIS_URL=redis://redis:6379
       # Mandatory for GitPod to map host env to the container, thus GitPod can dynamically configure the public URL of Logto;
       # Or, you can leverage it for local testing.
       - ENDPOINT
       - ADMIN_ENDPOINT
-  postgres:
-    image: postgres:17-alpine
-    user: postgres
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: p0stgr3s
+  mongodb:
+    image: mongo:7
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
       interval: 10s
       timeout: 5s
       retries: 5
+    ports:
+      - 27017:27017
+  mongodb-setup:
+    image: mongo:7
+    depends_on:
+      mongodb:
+        condition: service_started
+    entrypoint: ["sh", "-c", "for i in $(seq 1 30); do mongosh mongodb://mongodb:27017 --eval 'db.adminCommand({ping:1})' && break || sleep 1; done && mongosh mongodb://mongodb:27017 --eval 'rs.initiate()' && sleep infinity"]
+  opensearch:
+    image: opensearchproject/opensearch:2
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - cluster.name=logto-opensearch
+      - node.name=node-1
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - 9200:9200
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+  redis:
+    image: redis:7-alpine
+    ports:
+      - 6379:6379


### PR DESCRIPTION
## Summary
- swap Postgres service for MongoDB replica set, OpenSearch and Redis
- expose new environment variables for app container
- adjust Gitpod config to run the new services
- document launching the stack in README and CONTRIBUTING

## Testing
- `pnpm -r lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684c34c033bc832f869e0dd1e3702522