### PR TITLE
Add Mongo query abstraction

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -136,7 +136,9 @@
     "sinon": "^19.0.0",
     "supertest": "^7.0.0",
     "tsup": "^8.3.0",
-    "typescript": "^5.5.3"
+    "typescript": "^5.5.3",
+    "mongoose": "^7.6.1",
+    "mongodb-memory-server": "^9.7.1"
   },
   "engines": {
     "node": "^22.14.0"

--- a/packages/core/src/database/mongo-connection.ts
+++ b/packages/core/src/database/mongo-connection.ts
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+const createMongoConnectionByEnv = async (
+  mongoUri: string,
+  mockDatabaseConnection: boolean
+) => {
+  const uri = mockDatabaseConnection
+    ? (await MongoMemoryServer.create()).getUri()
+    : mongoUri;
+
+  await mongoose.connect(uri);
+  return mongoose.connection;
+};
+
+export default createMongoConnectionByEnv;

--- a/packages/core/src/database/mongo-schema-queries.ts
+++ b/packages/core/src/database/mongo-schema-queries.ts
@@ -1,0 +1,33 @@
+import type { Model } from 'mongoose';
+
+export default class MongoSchemaQueries<Schema extends { id: string }> {
+  constructor(protected readonly model: Model<Schema>) {}
+
+  async findAll(limit = 20, offset = 0): Promise<[number, Schema[]]> {
+    const [count, docs] = await Promise.all([
+      this.model.countDocuments({}),
+      this.model.find({}).skip(offset).limit(limit).lean<Schema>().exec(),
+    ]);
+    return [count, docs];
+  }
+
+  async findById(id: string): Promise<Schema | null> {
+    return this.model.findOne({ id }).lean<Schema>().exec();
+  }
+
+  async insert(data: Schema): Promise<Schema> {
+    const doc = await this.model.create(data);
+    return doc.toObject();
+  }
+
+  async updateById(id: string, data: Partial<Schema>): Promise<Schema | null> {
+    return this.model
+      .findOneAndUpdate({ id }, data, { new: true })
+      .lean<Schema>()
+      .exec();
+  }
+
+  async deleteById(id: string): Promise<void> {
+    await this.model.deleteOne({ id }).exec();
+  }
+}

--- a/packages/core/src/queries/account-center.mongo.test.ts
+++ b/packages/core/src/queries/account-center.mongo.test.ts
@@ -1,0 +1,32 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+import { type AccountCenter } from '@logto/schemas';
+
+import { WellKnownCache } from '../caches/well-known.js';
+import { AccountCenterMongoQueries } from './account-center.mongo.js';
+
+const DEFAULT_ID = 'default';
+
+describe('AccountCenterMongoQueries', () => {
+  let server: MongoMemoryServer;
+
+  beforeAll(async () => {
+    server = await MongoMemoryServer.create();
+    await mongoose.connect(server.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await server.stop();
+  });
+
+  it('should insert and fetch the default account center', async () => {
+    const cache = new WellKnownCache('t1', new Map());
+    const queries = new AccountCenterMongoQueries(cache);
+    await queries.insert({ id: DEFAULT_ID } as AccountCenter);
+
+    const result = await queries.findDefaultAccountCenter();
+    expect(result?.id).toBe(DEFAULT_ID);
+  });
+});

--- a/packages/core/src/queries/account-center.mongo.ts
+++ b/packages/core/src/queries/account-center.mongo.ts
@@ -1,0 +1,37 @@
+import type { AccountCenter } from '@logto/schemas';
+import mongoose from 'mongoose';
+
+import type { WellKnownCache } from '../caches/well-known.js';
+import MongoSchemaQueries from '../database/mongo-schema-queries.js';
+
+const AccountCenterSchema = new mongoose.Schema<AccountCenter>({
+  id: { type: String, required: true, unique: true },
+  displayName: String,
+  logoUri: String,
+  primaryColor: String,
+});
+
+const AccountCenterModel = mongoose.models.AccountCenter ||
+  mongoose.model<AccountCenter>('AccountCenter', AccountCenterSchema);
+
+const DEFAULT_ID = 'default';
+
+export class AccountCenterMongoQueries extends MongoSchemaQueries<AccountCenter> {
+  public readonly findDefaultAccountCenter = this.wellKnownCache.memoize(
+    async () => this.findById(DEFAULT_ID),
+    ['account-center']
+  );
+
+  public readonly updateDefaultAccountCenter = this.wellKnownCache.mutate(
+    async (accountCenter: Partial<AccountCenter>) =>
+      this.updateById(DEFAULT_ID, accountCenter),
+    ['account-center']
+  );
+
+  constructor(public readonly wellKnownCache: WellKnownCache) {
+    super(AccountCenterModel);
+  }
+}
+
+export const createAccountCenterMongoQueries = (wellKnownCache: WellKnownCache) =>
+  new AccountCenterMongoQueries(wellKnownCache);


### PR DESCRIPTION
## Summary
- add Mongo connection helper mirroring `createPoolByEnv`
- implement `MongoSchemaQueries` for basic CRUD
- create Mongo-backed `AccountCenter` queries
- add test using `mongodb-memory-server`
- include Mongo packages in devDependencies

## Testing
- `pnpm -r test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c34be20fc832fa80445863e3a361d