### PR TITLE
Fix README local dev section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ Pick your path:
 - **Local development:**  
 
   ```bash
- <<<<<<< codex/reemplazar-servicio-postgres-con-mongodb,-opensearch-y-redis
 # Using Docker Compose (requires Docker Desktop)
-  docker compose up
+docker compose up
 
 # The services are available on the following URLs:
 # MongoDB: mongodb://localhost:27017/?replicaSet=rs0
@@ -69,13 +68,6 @@ Pick your path:
 # Redis: redis://localhost:6379
 
 # Using Node.js
-=======
-# Using Docker Compose(requires Docker Desktop)
-  curl -fsSL https://raw.githubusercontent.com/logto-io/logto/HEAD/docker-compose.yml | \
-  docker compose -p logto -f - up
-
-# Using Node.js (requires PostgreSQL)
- >>>>>>> master
   npm init @logto
   ```
 
@@ -84,7 +76,8 @@ Pick your path:
 Set required environment variables in a `.env` file or export them directly:
 
 ```env
-DB_URL=postgres://postgres:postgres@localhost:5432/logto
+MONGODB_URI=mongodb://localhost:27017/?replicaSet=rs0
+OPENSEARCH_URL=http://localhost:9200
 REDIS_URL=redis://localhost:6379
 ENDPOINT=http://localhost:3001
 ADMIN_ENDPOINT=http://localhost:3002


### PR DESCRIPTION
## Summary
- remove merge conflict markers from the local development section
- use MongoDB, OpenSearch and Redis URLs like in contribution guide

## Testing
- `pnpm ci:lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c41e40ba8832fa8b2405a7a8c1f6d