### PR TITLE
Add OpenSearch client

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Set required environment variables in a `.env` file or export them directly:
 ```env
 DB_URL=postgres://postgres:postgres@localhost:5432/logto
 REDIS_URL=redis://localhost:6379
+OPENSEARCH_URL=http://localhost:9200
 ENDPOINT=http://localhost:3001
 ADMIN_ENDPOINT=http://localhost:3002
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,7 @@
     "@silverhand/slonik": "31.0.0-beta.2",
     "@simplewebauthn/server": "^10.0.0",
     "@withtyped/client": "^0.8.8",
+    "@opensearch-project/opensearch": "^2.0.0",
     "camelcase": "^8.0.0",
     "camelcase-keys": "^9.1.3",
     "chalk": "^5.3.0",

--- a/packages/core/src/search/opensearch.test.ts
+++ b/packages/core/src/search/opensearch.test.ts
@@ -1,0 +1,37 @@
+import { createMockUtils } from '@logto/shared/esm';
+import Sinon from 'sinon';
+
+import { EnvSet } from '#src/env-set/index.js';
+
+const { jest } = import.meta;
+const { mockEsm } = createMockUtils(jest);
+
+const mockClient = jest.fn();
+
+mockEsm('@opensearch-project/opensearch', () => ({
+  Client: jest.fn().mockImplementation(() => ({ search: mockClient })),
+}));
+
+const { createOpenSearchClient } = await import('./opensearch.js');
+
+describe('createOpenSearchClient', () => {
+  it('should return undefined if no OPENSEARCH_URL', () => {
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      opensearchUrl: undefined,
+    });
+
+    expect(createOpenSearchClient()).toBeUndefined();
+    stub.restore();
+  });
+
+  it('should create a client when OPENSEARCH_URL is provided', () => {
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      opensearchUrl: 'http://localhost:9200',
+    });
+
+    expect(createOpenSearchClient()).toBeTruthy();
+    stub.restore();
+  });
+});

--- a/packages/core/src/search/opensearch.ts
+++ b/packages/core/src/search/opensearch.ts
@@ -1,0 +1,14 @@
+import { Client } from '@opensearch-project/opensearch';
+
+import { EnvSet } from '../env-set/index.js';
+
+/**
+ * Initialize an OpenSearch client with the configured URL.
+ * Returns `undefined` if `OPENSEARCH_URL` is not provided.
+ */
+export const createOpenSearchClient = () => {
+  const { opensearchUrl } = EnvSet.values;
+  return opensearchUrl ? new Client({ node: opensearchUrl }) : undefined;
+};
+
+export const openSearchClient = createOpenSearchClient();

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -113,8 +113,11 @@ export default class GlobalValues {
    * The Redis endpoint (optional). If it's set, the central cache mechanism will be automatically enabled.
    *
    * You can set it to a truthy value like `true` or `1` to enable cache with the default Redis URL.
-   */
+  */
   public readonly redisUrl = getEnv('REDIS_URL');
+
+  /** OpenSearch endpoint for search service. */
+  public readonly opensearchUrl = getEnv('OPENSEARCH_URL');
 
   public get dbUrl(): string {
     return this.databaseUrl;


### PR DESCRIPTION
## Summary
- add OPENSEARCH_URL config
- create OpenSearch client module with tests
- document OPENSEARCH_URL in README

## Testing
- `pnpm -r test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c41fa4aa8832f9ae5193c7d9dce9d