### PR TITLE
feat(docker): add optional Redis cluster

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -67,6 +67,8 @@ You'll need these installed to proceed:
 - [Node.js](https://nodejs.org/) `^18.12.0`
 - [pnpm](https://pnpm.io/) `^9.0`
 - A local MongoDB replica set, OpenSearch, and Redis instance (see `docker-compose.yml`)
+  - Start them with `docker compose up -d`
+  - For Redis cluster support run `docker compose --profile cluster up -d` and set `REDIS_URL=redis://localhost:7000?cluster=1`
 
 ### Clone and install dependencies
 
@@ -86,6 +88,8 @@ Create a `.env` file with the following content in the project root, or set the 
 MONGODB_URI=mongodb://localhost:27017/?replicaSet=rs0
 OPENSEARCH_URL=http://localhost:9200
 REDIS_URL=redis://localhost:6379
+# Use the cluster URL if the Redis cluster profile is enabled
+# REDIS_URL=redis://localhost:7000?cluster=1
 ```
 
 ### Database alteration

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Pick your path:
 # MongoDB: mongodb://localhost:27017/?replicaSet=rs0
 # OpenSearch: http://localhost:9200
 # Redis: redis://localhost:6379
+# Redis cluster (optional): redis://localhost:7000?cluster=1
 
 # Using Node.js
 =======
@@ -86,6 +87,8 @@ Set required environment variables in a `.env` file or export them directly:
 ```env
 DB_URL=postgres://postgres:postgres@localhost:5432/logto
 REDIS_URL=redis://localhost:6379
+# Use the cluster URL if running the "cluster" profile
+# REDIS_URL=redis://localhost:7000?cluster=1
 ENDPOINT=http://localhost:3001
 ADMIN_ENDPOINT=http://localhost:3002
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - MONGODB_URI=mongodb://mongodb:27017/?replicaSet=rs0
       - OPENSEARCH_URL=http://opensearch:9200
       - REDIS_URL=redis://redis:6379
+      # Use the line below for Redis cluster (enable the "cluster" profile)
+      # - REDIS_URL=redis://redis-cluster:7000?cluster=1
       # Mandatory for GitPod to map host env to the container, thus GitPod can dynamically configure the public URL of Logto;
       # Or, you can leverage it for local testing.
       - ENDPOINT
@@ -57,3 +59,11 @@ services:
     image: redis:7-alpine
     ports:
       - 6379:6379
+  redis-cluster:
+    image: bitnami/redis-cluster:7
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - "7000-7005:7000-7005"
+    profiles:
+      - cluster

--- a/packages/core/src/caches/redis-cluster.integration.test.ts
+++ b/packages/core/src/caches/redis-cluster.integration.test.ts
@@ -1,0 +1,14 @@
+import { RedisClusterCache } from './index.js';
+
+const url = process.env.REDIS_CLUSTER_URL;
+
+(url ? describe : describe.skip)('RedisClusterCache integration', () => {
+  it('should ping successfully', async () => {
+    const cache = new RedisClusterCache(new URL(url!));
+    await cache.connect();
+    const result = await cache['ping']();
+    await cache.disconnect();
+    expect(result).toBe('PONG');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Redis cluster support in docker-compose
- document cluster mode in README and CONTRIBUTING
- add integration test for RedisClusterCache when `REDIS_CLUSTER_URL` is provided

## Testing
- `pnpm -r --parallel --workspace-concurrency=0 test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c41fea970832faab2cefa3d7c6647