### PR TITLE
Add optional redis cluster note

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ If you find Logto helpful, here's how you can support us:
 - [Tenant usage refactor](./docs-ref/tenant-usage-refactor.md)
 - [WebAuthn utils refactor](./docs-ref/webauthn-refactor.md)
 - [Verification records refactor](./docs-ref/verification-records-refactor.md)
+- [Optional Redis Cluster](./docs-ref/optional-redis-cluster.md)
 
 
 ## Licensing

--- a/docs-ref/optional-redis-cluster.md
+++ b/docs-ref/optional-redis-cluster.md
@@ -1,0 +1,16 @@
+# Optional Redis Cluster
+
+**File paths**
+- `docker-compose.yml`
+- `packages/core/src/caches/index.ts`
+- `.github/CONTRIBUTING.md`
+- `README.md`
+
+**Key changes**
+- New `redis-cluster` service enabled via the "cluster" profile.
+- `REDIS_URL` accepts `?cluster=1` to enable cluster mode.
+- `RedisClusterCache` automatically used when `cluster` query param is present.
+- Updated docs with instructions for running the cluster profile.
+
+**New dependencies / environment variables**
+- None.


### PR DESCRIPTION
## Summary
- document optional redis cluster settings
- list optional redis cluster doc under refactor notes

## Testing
- `pnpm ci:lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm ci:test` *(fails: vitest not found and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c47dd82f8832fa089e15a1bddb2b0