### PR TITLE
Fix CopyToClipboard margin

### DIFF
--- a/packages/console/src/ds-components/CopyToClipboard/index.module.scss
+++ b/packages/console/src/ds-components/CopyToClipboard/index.module.scss
@@ -30,6 +30,10 @@
     cursor: text;
     gap: _.unit(2);
 
+    .copyToolTipAnchor {
+      margin-inline-start: 0;
+    }
+
     .content {
       flex: 1;
       overflow: hidden;

--- a/packages/console/src/ds-components/CopyToClipboard/index.tsx
+++ b/packages/console/src/ds-components/CopyToClipboard/index.tsx
@@ -124,7 +124,11 @@ function CopyToClipboard(
             </IconButton>
           </Tooltip>
         )}
-        <Tooltip isSuccessful={copyState === 'copied'} content={t(copyState)}>
+        <Tooltip
+          isSuccessful={copyState === 'copied'}
+          content={t(copyState)}
+          anchorClassName={styles.copyToolTipAnchor}
+        >
           <IconButton
             ref={copyIconReference}
             className={styles.iconButton}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.module.scss
@@ -62,11 +62,6 @@
         &:active {
           background: var(--color-overlay-dark-bg-pressed);
         }
-
-        // TODO (LOG-8602): Remove the default left margin of CopyToClipboard copyToolTipAnchor component.
-        div[class*='copyToolTipAnchor'] {
-          margin-inline-start: 0;
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- ensure CopyToClipboard tooltip anchor has no default margin
- remove obsolete margin override in MonacoCodeEditor

## Testing
- `pnpm -r lint` *(fails: ESLint couldn't find dependencies)*
- `pnpm -r stylelint` *(fails: stylelint not found)*
- `pnpm -r test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7de3da4c832fb080e78d2b6e7580