### PR TITLE
Add failure cases for sendMessage tests

### DIFF
--- a/packages/connectors/connector-logto-email/src/index.test.ts
+++ b/packages/connectors/connector-logto-email/src/index.test.ts
@@ -1,4 +1,5 @@
 import { got } from 'got';
+import { HTTPError } from 'got';
 import nock from 'nock';
 
 import { TemplateType } from '@logto/connector-kit';
@@ -40,6 +41,19 @@ describe('sendMessage()', () => {
         payload: { code: '1234' },
       })
     ).resolves.not.toThrow();
+  });
+
+  it('should throw when service responds with error', async () => {
+    const url = buildUrl(emailEndpoint, endpoint);
+    nock(url.origin).post(url.pathname).reply(400);
+    const { sendMessage } = await createConnector({ getConfig, getCloudServiceClient });
+    await expect(
+      sendMessage({
+        to: 'error@example.com',
+        type: TemplateType.SignIn,
+        payload: { code: '1234' },
+      })
+    ).rejects.toThrow(HTTPError);
   });
 
   it('should get usage successfully', async () => {

--- a/packages/connectors/connector-logto-sms/src/index.test.ts
+++ b/packages/connectors/connector-logto-sms/src/index.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import { HTTPError } from 'got';
 
 import { TemplateType } from '@logto/connector-kit';
 
@@ -24,5 +25,17 @@ describe('sendMessage()', () => {
         payload: { code: '1234' },
       })
     ).resolves.not.toThrow();
+  });
+
+  it('should throw when service returns error', async () => {
+    nock(mockedConfig.endpoint).post(smsEndpoint).reply(500);
+    const connector = await createConnector({ getConfig });
+    await expect(
+      connector.sendMessage({
+        to: '13000000000',
+        type: TemplateType.SignIn,
+        payload: { code: '1234' },
+      })
+    ).rejects.toThrow(HTTPError);
   });
 });

--- a/packages/connectors/connector-yunpian-sms/src/index.test.ts
+++ b/packages/connectors/connector-yunpian-sms/src/index.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 
-import { TemplateType } from '@logto/connector-kit';
+import { TemplateType, ConnectorError } from '@logto/connector-kit';
 
 import { endpoint } from './constant.js';
 import createConnector from './index.js';
@@ -49,6 +49,24 @@ describe('yunpian SMS connector', () => {
           payload: { code: '1234' },
         })
       ).resolves.not.toThrow();
+    });
+
+    it('should throw connector error on failure', async () => {
+      const errorResponse = {
+        http_status_code: 400,
+        code: 9,
+        msg: 'error',
+      };
+
+      nock(endpoint).post('').reply(400, errorResponse);
+
+      await expect(
+        sendMessage({
+          to: '13800138000',
+          type: TemplateType.Generic,
+          payload: { code: '1234' },
+        })
+      ).rejects.toBeInstanceOf(ConnectorError);
     });
   });
 });


### PR DESCRIPTION
## Summary
- test failure cases for Logto email, Logto SMS, and Yunpian SMS connectors

## Testing
- `pnpm -r --filter @logto/connector-logto-email test:ci` *(fails: vitest not found)*
- `pnpm -r --filter ./packages/connectors/connector-yunpian-sms test:ci` *(fails: vitest not found)*
- `pnpm -r --filter ./packages/connectors/connector-logto-sms test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c78ffbfd4832fbce69f0715b69a14