### PR TITLE
Update experience package to ESM tests

### DIFF
--- a/packages/experience/jest.config.ts
+++ b/packages/experience/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config.InitialOptions = {
   roots: ['<rootDir>/src'],
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/jest.setup.ts'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
   collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}'],
   coveragePathIgnorePatterns: ['/node_modules/', '/src/__mocks__/', '/src/include.d/'],
   coverageReporters: ['text-summary', 'lcov'],
@@ -12,6 +13,7 @@ const config: Config.InitialOptions = {
       '@swc/jest',
       {
         sourceMaps: true,
+        module: { type: 'es6' },
         jsc: {
           transform: {
             react: {

--- a/packages/experience/package.json
+++ b/packages/experience/package.json
@@ -16,8 +16,9 @@
     "lint": "eslint --ext .ts --ext .tsx src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "stylelint": "stylelint \"src/**/*.scss\"",
-    "test:ci": "jest --coverage --silent",
-    "test": "jest"
+    "test:only": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:ci": "NODE_OPTIONS=--experimental-vm-modules jest --coverage --silent",
+    "test": "pnpm test:only"
   },
   "devDependencies": {
     "@jest/types": "^29.5.0",

--- a/packages/experience/src/constants/env.ts
+++ b/packages/experience/src/constants/env.ts
@@ -1,4 +1,4 @@
 import { yes } from '@silverhand/essentials';
 
 export const isDevFeaturesEnabled =
-  process.env.NODE_ENV !== 'production' || yes(process.env.DEV_FEATURES_ENABLED);
+  import.meta.env.PROD === false || yes(import.meta.env.DEV_FEATURES_ENABLED);

--- a/packages/experience/vite.config.ts
+++ b/packages/experience/vite.config.ts
@@ -27,16 +27,9 @@ const buildConfig = (mode: string): UserConfig => ({
     viteCompression({ disable: mode === 'development', algorithm: 'brotliCompress' }),
   ],
   define: {
-    // TODO: Remove this line after the experience package supports ESM unit test.
-    // Replace all the process.env references with import.meta.env in the experience package then.
-    // 'import.meta.env.DEV_FEATURES_ENABLED': JSON.stringify(process.env.DEV_FEATURES_ENABLED),
-
-    // Experience package does not support ESM unit test yet, can not use import.meta.env
-    // so we need to define the environment variables here.
-    'process.env': {
-      NODE_ENV: process.env.NODE_ENV,
-      DEV_FEATURES_ENABLED: process.env.DEV_FEATURES_ENABLED,
-    },
+    'import.meta.env.DEV_FEATURES_ENABLED': JSON.stringify(
+      process.env.DEV_FEATURES_ENABLED
+    ),
   },
   build: {
     // Use the same browserslist configuration as in README.md.


### PR DESCRIPTION
## Summary
- run experience tests in ESM mode
- use `import.meta.env` for dev feature flag
- clean up build config

## Testing
- `pnpm --filter @logto/experience test:only` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c78ff23a4832f97e53531fe13d57e