### PR TITLE
Add nonce-specific connector error codes

### DIFF
--- a/packages/connectors/connector-apple/src/index.ts
+++ b/packages/connectors/connector-apple/src/index.ts
@@ -74,7 +74,6 @@ const getUserInfo =
       });
 
       if (payload.nonce) {
-        // TODO @darcy: need to specify error code
         assert(
           getSession,
           new ConnectorError(ConnectorErrorCodes.NotImplemented, {
@@ -85,14 +84,14 @@ const getUserInfo =
 
         assert(
           validationNonce,
-          new ConnectorError(ConnectorErrorCodes.General, {
+          new ConnectorError(ConnectorErrorCodes.NonceMissing, {
             message: "'nonce' not presented in session storage.",
           })
         );
 
         assert(
           validationNonce === payload.nonce,
-          new ConnectorError(ConnectorErrorCodes.SocialIdTokenInvalid, {
+          new ConnectorError(ConnectorErrorCodes.NonceMismatch, {
             message: "IdToken validation failed due to 'nonce' mismatch.",
           })
         );

--- a/packages/connectors/connector-oidc/src/index.ts
+++ b/packages/connectors/connector-oidc/src/index.ts
@@ -127,17 +127,16 @@ const getUserInfo =
       } = result.data;
 
       if (nonce) {
-        // TODO @darcy: need to specify error code
         assert(
           validationNonce,
-          new ConnectorError(ConnectorErrorCodes.General, {
+          new ConnectorError(ConnectorErrorCodes.NonceMissing, {
             message: 'Cannot find `nonce` in session storage.',
           })
         );
 
         assert(
           validationNonce === nonce,
-          new ConnectorError(ConnectorErrorCodes.SocialIdTokenInvalid, {
+          new ConnectorError(ConnectorErrorCodes.NonceMismatch, {
             message: 'ID Token validation failed due to `nonce` mismatch.',
           })
         );

--- a/packages/toolkit/connector-kit/src/types/error.ts
+++ b/packages/toolkit/connector-kit/src/types/error.ts
@@ -22,6 +22,14 @@ export enum ConnectorErrorCodes {
   SocialAccessTokenInvalid = 'social_invalid_access_token',
   SocialIdTokenInvalid = 'social_invalid_id_token',
   AuthorizationFailed = 'authorization_failed',
+  /**
+   * The nonce stored in session is missing while validating the ID token.
+   */
+  NonceMissing = 'nonce_missing',
+  /**
+   * The nonce provided in ID token does not match the one stored in session.
+   */
+  NonceMismatch = 'nonce_mismatch',
 }
 
 export class ConnectorError extends Error {


### PR DESCRIPTION
## Summary
- add `NonceMissing` and `NonceMismatch` error codes to connector-kit
- use new codes in Apple and generic OIDC connectors

## Testing
- `pnpm -r --parallel --workspace-concurrency=0 test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c78fe5018832fa1127b570185ec63