### PR TITLE
Use connector kit token grant helper

### DIFF
--- a/packages/connectors/connector-logto-sms/package.json
+++ b/packages/connectors/connector-logto-sms/package.json
@@ -5,6 +5,7 @@
   "author": "Silverhand Inc. <contact@silverhand.io>",
   "dependencies": {
     "@logto/connector-kit": "workspace:^4.3.0",
+    "@logto/connector-oauth": "workspace:^1.6.0",
     "@silverhand/essentials": "^2.9.1",
     "got": "^14.0.0",
     "snakecase-keys": "^8.0.1",


### PR DESCRIPTION
## Summary
- use `requestTokenEndpoint` and `parseJson` for Logto SMS token grant
- list `@logto/connector-oauth` as a dependency

## Testing
- `pnpm --filter @logto/connector-logto-sms test` *(fails: spawn ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_684c78fcf49c832fa6875c4a4b725cc1