### PR TITLE
Align MFA error handling

### DIFF
--- a/packages/experience/src/hooks/use-send-mfa-payload.ts
+++ b/packages/experience/src/hooks/use-send-mfa-payload.ts
@@ -1,13 +1,11 @@
-import { InteractionEvent, type BindMfaPayload, type VerifyMfaPayload } from '@logto/schemas';
+import { type BindMfaPayload, type VerifyMfaPayload } from '@logto/schemas';
 import { useCallback } from 'react';
 
 import { bindMfa, verifyMfa } from '@/apis/experience';
 import { UserMfaFlow } from '@/types';
 
 import useApi from './use-api';
-import useErrorHandler, { type ErrorHandlers } from './use-error-handler';
 import useGlobalRedirectTo from './use-global-redirect-to';
-import useSubmitInteractionErrorHandler from './use-submit-interaction-error-handler';
 
 export type SendMfaPayloadApiOptions =
   | {
@@ -30,41 +28,20 @@ const sendMfaPayloadApi = async ({ flow, payload, verificationId }: SendMfaPaylo
 
 const useSendMfaPayload = () => {
   const asyncSendMfaPayload = useApi(sendMfaPayloadApi);
-  /**
-   * TODO: @simeng-li
-   * Need to find a better implementation.
-   * In the registration event, MFA binding flow is triggered after user creation,
-   * so the error handle logic is same as the pre-sign-in event.
-   * This is confusing and should be refactored.
-   */
-  const preSignInErrorHandler = useSubmitInteractionErrorHandler(InteractionEvent.SignIn, {
-    replace: true,
-  });
-  const handleError = useErrorHandler();
   const redirectTo = useGlobalRedirectTo();
 
   return useCallback(
-    async (
-      apiOptions: SendMfaPayloadApiOptions,
-      errorHandlers?: ErrorHandlers,
-      errorCallback?: () => void
-    ) => {
-      const [error, result] = await asyncSendMfaPayload(apiOptions);
-
-      if (error) {
-        await handleError(error, {
-          ...errorHandlers,
-          ...preSignInErrorHandler,
-        });
-        errorCallback?.();
-        return;
-      }
+    async (apiOptions: SendMfaPayloadApiOptions) => {
+      const resultTuple = await asyncSendMfaPayload(apiOptions);
+      const [, result] = resultTuple;
 
       if (result) {
         await redirectTo(result.redirectTo);
       }
+
+      return resultTuple;
     },
-    [asyncSendMfaPayload, handleError, preSignInErrorHandler, redirectTo]
+    [asyncSendMfaPayload, redirectTo]
   );
 };
 


### PR DESCRIPTION
## Summary
- remove internal error handling from useSendMfaPayload
- update MFA pages and hooks to handle errors explicitly

## Testing
- `pnpm -F @logto/experience lint` *(fails: ESLint couldn't find config)*
- `pnpm -F @logto/experience test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c78f8978c832f82a714cf0ae0be99