### PR TITLE
Add isRequestError helper and clarify SSO flow docs

### DIFF
--- a/packages/core/src/errors/RequestError/index.ts
+++ b/packages/core/src/errors/RequestError/index.ts
@@ -88,3 +88,6 @@ export default class RequestError extends Error {
     };
   }
 }
+
+export const isRequestError = (error: unknown): error is RequestError =>
+  error instanceof RequestError;

--- a/packages/core/src/libraries/domain.ts
+++ b/packages/core/src/libraries/domain.ts
@@ -1,7 +1,7 @@
 import { type CloudflareData, type Domain, DomainStatus } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import SystemContext from '#src/tenants/SystemContext.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -104,7 +104,7 @@ export const createDomainLibrary = (queries: Queries) => {
         await deleteCustomHostname(hostnameProviderConfig, domain.cloudflareData.id);
       } catch (error: unknown) {
         // Ignore not found error, since we are deleting the domain anyway
-        if (!(error instanceof RequestError) || error.code !== 'domain.cloudflare_not_found') {
+        if (!isRequestError(error) || error.code !== 'domain.cloudflare_not_found') {
           throw error;
         }
       }

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -5,7 +5,7 @@ import { got } from 'got';
 import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
 const validateCustomBlockListFormat = (list: string[]) => {
@@ -102,7 +102,7 @@ const validateDisposableEmailDomain = async (email: string) => {
       })
     );
   } catch (error: unknown) {
-    if (error instanceof RequestError) {
+    if (isRequestError(error)) {
       throw error;
     }
 

--- a/packages/core/src/libraries/social.ts
+++ b/packages/core/src/libraries/social.ts
@@ -6,7 +6,7 @@ import type { Nullable } from '@silverhand/essentials';
 import type { InteractionResults } from 'oidc-provider';
 import { z } from 'zod';
 
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import type { ConnectorLibrary } from '#src/libraries/connector.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -44,7 +44,7 @@ export const createSocialLibrary = (queries: Queries, connectorLibrary: Connecto
       return await getLogtoConnectorById(connectorId);
     } catch (error: unknown) {
       // Throw a new error with status 422 when connector not found.
-      if (error instanceof RequestError && error.code === 'entity.not_found') {
+      if (isRequestError(error) && error.code === 'entity.not_found') {
         throw new RequestError({
           code: 'session.invalid_connector_id',
           status: 422,

--- a/packages/core/src/middleware/koa-audit-log.ts
+++ b/packages/core/src/middleware/koa-audit-log.ts
@@ -5,7 +5,7 @@ import { pick } from '@silverhand/essentials';
 import type { Context, MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -149,7 +149,7 @@ export default function koaAuditLog<StateT, ContextT extends IRouterParamContext
         entry.append({
           result: LogResult.Error,
           error:
-            error instanceof RequestError
+            isRequestError(error)
               ? pick(error, 'message', 'code', 'data')
               : { message: String(error) },
         });

--- a/packages/core/src/middleware/koa-auth/index.ts
+++ b/packages/core/src/middleware/koa-auth/index.ts
@@ -8,7 +8,7 @@ import { HTTPError } from 'ky';
 import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 import { devConsole } from '#src/utils/console.js';
 
@@ -71,7 +71,7 @@ export const verifyBearerTokenFromRequest = async (
 
     return { sub, clientId, scopes: z.string().parse(scope).split(' ') };
   } catch (error: unknown) {
-    if (error instanceof RequestError) {
+    if (isRequestError(error)) {
       throw error;
     }
 

--- a/packages/core/src/middleware/koa-consent-guard.ts
+++ b/packages/core/src/middleware/koa-consent-guard.ts
@@ -3,7 +3,7 @@ import { type MiddlewareType } from 'koa';
 import { type IRouterParamContext } from 'koa-router';
 import { type Provider } from 'oidc-provider';
 
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -58,7 +58,7 @@ export default function koaConsentGuard<
           });
         }
       } catch (error: unknown) {
-        if (error instanceof RequestError) {
+        if (isRequestError(error)) {
           // Green light for token in consumed state
           if (error.code === 'one_time_token.token_consumed') {
             return next();

--- a/packages/core/src/middleware/koa-error-handler.ts
+++ b/packages/core/src/middleware/koa-error-handler.ts
@@ -5,7 +5,7 @@ import type { Middleware } from 'koa';
 import { HttpError } from 'koa';
 
 import { EnvSet } from '#src/env-set/index.js';
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
@@ -34,7 +34,7 @@ export default function koaErrorHandler<
       // Report all exceptions to ApplicationInsights
       void appInsights.trackException(error, buildAppInsightsTelemetry(ctx));
 
-      if (error instanceof RequestError) {
+      if (isRequestError(error)) {
         ctx.status = error.status;
         ctx.body = error.toBody(ctx.i18n);
 

--- a/packages/core/src/middleware/koa-guard.ts
+++ b/packages/core/src/middleware/koa-guard.ts
@@ -7,7 +7,7 @@ import type { IMiddleware, IRouterParamContext } from 'koa-router';
 import type { ZodType, ZodTypeDef } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import { ResponseBodyError, StatusCodeError } from '#src/errors/ServerError/index.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
@@ -219,7 +219,7 @@ export default function koaGuard<
       // Assert the status code from `RequestError` that is thrown by inner middleware.
       // Ignore guard errors since they will be always 400 and can be automatically documented
       // in the OpenAPI route.
-      if (error instanceof RequestError && !error.code.startsWith('guard.')) {
+      if (isRequestError(error) && !error.code.startsWith('guard.')) {
         assertStatusCode(error.status);
       }
 

--- a/packages/core/src/middleware/koa-token-usage-guard.ts
+++ b/packages/core/src/middleware/koa-token-usage-guard.ts
@@ -3,7 +3,7 @@ import { adminTenantId, ReservedPlanId } from '@logto/schemas';
 import { type Nullable } from '@silverhand/essentials';
 import { type MiddlewareType } from 'koa';
 
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import { type SubscriptionLibrary } from '#src/libraries/subscription.js';
 import assertThat from '#src/utils/assert-that.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
@@ -64,7 +64,7 @@ export default function koaTokenUsageGuard<StateT, ContextT, ResponseBodyT>(
         })
       );
     } catch (error: unknown) {
-      if (error instanceof RequestError) {
+      if (isRequestError(error)) {
         throw error;
       }
 

--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -11,7 +11,7 @@ import { conditional, trySafe } from '@silverhand/essentials';
 import { type IRouterContext } from 'koa-router';
 
 import { EnvSet } from '#src/env-set/index.js';
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import { type CloudConnectionLibrary } from '#src/libraries/cloud-connection.js';
 import assertThat from '#src/utils/assert-that.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
@@ -125,7 +125,7 @@ export const identifyUserByVerificationRecord = async (
         return { user, syncedProfile };
       } catch (error: unknown) {
         // Auto fallback to identify the related user if the user does not exist for enterprise SSO.
-        if (error instanceof RequestError && error.code === 'user.identity_not_exist') {
+        if (isRequestError(error) && error.code === 'user.identity_not_exist') {
           const user = await verificationRecord.identifyRelatedUser();
 
           const syncedProfile = {

--- a/packages/core/src/routes/saml-application/anonymous.ts
+++ b/packages/core/src/routes/saml-application/anonymous.ts
@@ -7,7 +7,7 @@ import { addMinutes } from 'date-fns';
 import { z } from 'zod';
 
 import { spInitiatedSamlSsoSessionCookieName } from '#src/constants/index.js';
-import RequestError from '#src/errors/RequestError/index.js';
+import RequestError, { isRequestError } from '#src/errors/RequestError/index.js';
 import koaAuditLog from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type { AnonymousRouter, RouterInitArgs } from '#src/routes/types.js';
@@ -320,7 +320,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
 
         ctx.redirect(signInUrl.toString());
       } catch (error: unknown) {
-        if (error instanceof RequestError) {
+        if (isRequestError(error)) {
           throw error;
         }
 
@@ -418,7 +418,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
 
         ctx.redirect(signInUrl.toString());
       } catch (error: unknown) {
-        if (error instanceof RequestError) {
+        if (isRequestError(error)) {
           throw error;
         }
 

--- a/packages/core/src/sso/types/session.ts
+++ b/packages/core/src/sso/types/session.ts
@@ -41,10 +41,10 @@ export type CreateSingleSignOnSession = (storage: SingleSignOnConnectorSession) 
  * Single sign on interaction identifier result
  *
  * @remark this session data  is used to store the authentication result from the identity provider. {@link /packages/core/src/routes/interaction/utils/single-sign-on.ts}
- * This is needed because we need to split the authentication process into sign in and sign up two parts.
- * If the SSO identity is found in DB we will directly sign in the user.
- * If the SSO identity is not found in DB we will throw an error and let the client to create a new user.
- * In the SSO registration endpoint, we will validate this session data and create a new user accordingly.
+ * Historically the authentication process was divided into separate sign-in and registration phases.
+ * The result was stored here so the server could decide which flow to follow.
+ * The flows are now handled in a unified manner. If the SSO identity does not exist,
+ * the client will be prompted to register a new user using this stored information.
  *
  * Deprecated in the experience APIs. We will reply on the SSO verification record to store the authentication result.
  */


### PR DESCRIPTION
## Summary
- introduce `isRequestError` for clearer error handling
- refactor several modules to use the helper
- clarify SSO registration comment

## Testing
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c78f631b4832f8d90c15ff8da8c32