### PR TITLE
Fix CopyToClipboard anchor styles

### DIFF
--- a/packages/console/src/ds-components/CopyToClipboard/index.module.scss
+++ b/packages/console/src/ds-components/CopyToClipboard/index.module.scss
@@ -71,4 +71,10 @@
   .dot {
     -webkit-text-stroke: 1px var(--color-text);
   }
+
+  .copyToolTipAnchor {
+    display: flex;
+    align-items: center;
+    margin-inline-start: 0;
+  }
 }

--- a/packages/console/src/ds-components/CopyToClipboard/index.tsx
+++ b/packages/console/src/ds-components/CopyToClipboard/index.tsx
@@ -113,7 +113,10 @@ function CopyToClipboard(
           </div>
         )}
         {hasVisibilityToggle && (
-          <Tooltip content={t(showHiddenContent ? 'hide' : 'view')}>
+          <Tooltip
+            anchorClassName={styles.copyToolTipAnchor}
+            content={t(showHiddenContent ? 'hide' : 'view')}
+          >
             <IconButton
               className={styles.iconButton}
               iconClassName={styles.icon}
@@ -124,7 +127,11 @@ function CopyToClipboard(
             </IconButton>
           </Tooltip>
         )}
-        <Tooltip isSuccessful={copyState === 'copied'} content={t(copyState)}>
+        <Tooltip
+          anchorClassName={styles.copyToolTipAnchor}
+          isSuccessful={copyState === 'copied'}
+          content={t(copyState)}
+        >
           <IconButton
             ref={copyIconReference}
             className={styles.iconButton}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.module.scss
@@ -63,10 +63,6 @@
           background: var(--color-overlay-dark-bg-pressed);
         }
 
-        // TODO (LOG-8602): Remove the default left margin of CopyToClipboard copyToolTipAnchor component.
-        div[class*='copyToolTipAnchor'] {
-          margin-inline-start: 0;
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- style CopyToClipboard tooltip anchor
- clean up Monaco code editor styles by removing hack

## Testing
- `pnpm -r lint` *(fails: ESLint couldn't find config)*
- `pnpm -r stylelint` *(fails: stylelint not found)*
- `pnpm -r test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c783786e4832fbfac455a761e0560