### PR TITLE
Fix CopyToClipboard tooltip style

### DIFF
--- a/packages/console/src/ds-components/CopyToClipboard/index.module.scss
+++ b/packages/console/src/ds-components/CopyToClipboard/index.module.scss
@@ -72,3 +72,8 @@
     -webkit-text-stroke: 1px var(--color-text);
   }
 }
+
+.copyToolTipAnchor {
+  margin-inline-start: 0;
+}
+

--- a/packages/console/src/ds-components/CopyToClipboard/index.tsx
+++ b/packages/console/src/ds-components/CopyToClipboard/index.tsx
@@ -113,7 +113,10 @@ function CopyToClipboard(
           </div>
         )}
         {hasVisibilityToggle && (
-          <Tooltip content={t(showHiddenContent ? 'hide' : 'view')}>
+          <Tooltip
+            content={t(showHiddenContent ? 'hide' : 'view')}
+            anchorClassName={styles.copyToolTipAnchor}
+          >
             <IconButton
               className={styles.iconButton}
               iconClassName={styles.icon}
@@ -124,7 +127,11 @@ function CopyToClipboard(
             </IconButton>
           </Tooltip>
         )}
-        <Tooltip isSuccessful={copyState === 'copied'} content={t(copyState)}>
+        <Tooltip
+          isSuccessful={copyState === 'copied'}
+          content={t(copyState)}
+          anchorClassName={styles.copyToolTipAnchor}
+        >
           <IconButton
             ref={copyIconReference}
             className={styles.iconButton}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.module.scss
@@ -63,10 +63,6 @@
           background: var(--color-overlay-dark-bg-pressed);
         }
 
-        // TODO (LOG-8602): Remove the default left margin of CopyToClipboard copyToolTipAnchor component.
-        div[class*='copyToolTipAnchor'] {
-          margin-inline-start: 0;
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- support styling Tooltip anchor in `CopyToClipboard`
- remove local margin override in Monaco code editor

## Testing
- `pnpm ci:lint` *(fails: node modules missing)*
- `pnpm ci:stylelint` *(fails: stylelint not found)*
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5fade6dc832f9f7699a9bf3d013a