### PR TITLE
Handle connector identifiers

### DIFF
--- a/packages/core/src/routes/interaction/utils/index.ts
+++ b/packages/core/src/routes/interaction/utils/index.ts
@@ -20,6 +20,16 @@ export const isSocialIdentifier = (
 ): identifier is SocialConnectorPayload =>
   'connectorId' in identifier && 'connectorData' in identifier;
 
+export const isConnectorEmailIdentifier = (
+  identifier: IdentifierPayload
+): identifier is { connectorId: string; email: string } =>
+  'connectorId' in identifier && 'email' in identifier;
+
+export const isConnectorPhoneIdentifier = (
+  identifier: IdentifierPayload
+): identifier is { connectorId: string; phone: string } =>
+  'connectorId' in identifier && 'phone' in identifier;
+
 // Social identities can take place the role of password
 export const isUserPasswordSet = ({
   passwordEncrypted,

--- a/packages/core/src/routes/interaction/utils/sign-in-experience-validation.ts
+++ b/packages/core/src/routes/interaction/utils/sign-in-experience-validation.ts
@@ -1,8 +1,16 @@
 import type { SignInExperience, Profile, IdentifierPayload, MfaFactor } from '@logto/schemas';
-import { SignInMode, SignInIdentifier, InteractionEvent } from '@logto/schemas';
+import {
+  SignInMode,
+  SignInIdentifier,
+  InteractionEvent,
+} from '@logto/schemas';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
+import {
+  isConnectorEmailIdentifier,
+  isConnectorPhoneIdentifier,
+} from './index.js';
 
 const forbiddenEventError = () => new RequestError({ code: 'auth.forbidden', status: 403 });
 
@@ -45,7 +53,11 @@ export const verifyIdentifierSettings = (
 
   // Social Identifier  TODO: @darcy, @sijie
   // should not verify connector related identifier here
-  if ('connectorId' in identifier) {
+  if (
+    'connectorId' in identifier ||
+    isConnectorEmailIdentifier(identifier) ||
+    isConnectorPhoneIdentifier(identifier)
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- add utils to detect connector email/phone identifiers
- skip email/phone validation when connector identifiers are used

## Testing
- `pnpm ci:test` *(fails: connector packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a00f324832f96434d823a692190