### PR TITLE
Enable IdP‑initiated SSO by default

### DIFF
--- a/packages/core/src/routes/authn.ts
+++ b/packages/core/src/routes/authn.ts
@@ -207,8 +207,8 @@ export default function authnRoutes<T extends AnonymousRouter>(
       // All the rest of the request body will be validated and parsed by the connector.
       const { RelayState: jti } = body;
 
-      // IdP initiated SSO does not provide the RelayState, we need to check if the IdP initiated SSO flow is enabled.
-      if (!jti && EnvSet.values.isDevFeaturesEnabled) {
+      // IdP initiated SSO does not provide the RelayState
+      if (!jti) {
         const idpInitiatedAuthConfig =
           await queries.ssoConnectors.getIdpInitiatedAuthConfigByConnectorId(connectorId);
 
@@ -275,7 +275,6 @@ export default function authnRoutes<T extends AnonymousRouter>(
         return;
       }
 
-      // TODO: remove this assertion after the IdP initiated SSO flow is implemented
       assertThat(
         jti,
         new RequestError({

--- a/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines */
 import { createMockUtils } from '@logto/shared/esm';
 import type { Provider } from 'oidc-provider';
-import Sinon from 'sinon';
 
 import {
   mockSsoConnector,
@@ -359,10 +358,6 @@ describe('Single sign on util methods tests', () => {
   });
 
   describe('getSsoAuthorizationUrl tests with idp initiated sso session', () => {
-    const stub = Sinon.stub(EnvSet, 'values').value({
-      ...EnvSet.values,
-      isDevFeaturesEnabled: true,
-    });
 
     const payload = {
       state: 'state',
@@ -381,9 +376,6 @@ describe('Single sign on util methods tests', () => {
       }),
     };
 
-    afterAll(() => {
-      stub.restore();
-    });
 
     beforeEach(() => {
       getAuthorizationUrlMock.mockResolvedValueOnce(samlAuthorizationUrl);

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -64,11 +64,7 @@ export const getSsoAuthorizationUrl = async (
 
     const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
 
-    if (
-      // TODO: Remove this check when IdP-initiated SSO is fully supported
-      EnvSet.values.isDevFeaturesEnabled &&
-      connectorInstance instanceof SamlConnector
-    ) {
+    if (connectorInstance instanceof SamlConnector) {
       // Check if a IdP-initiated SSO session exists
       const sessionId = ctx.cookies.get(idpInitiatedSamlSsoSessionCookieName);
 

--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -304,8 +304,5 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
     }
   );
 
-  // TODO: @simeng Remove this when IdP initiated SAML SSO is ready for production
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    ssoConnectorIdpInitiatedAuthConfigRoutes(...args);
-  }
+  ssoConnectorIdpInitiatedAuthConfigRoutes(...args);
 }


### PR DESCRIPTION
## Summary
- remove `EnvSet.values.isDevFeaturesEnabled` checks from IdP‑initiated SSO paths
- update SSO session handling logic
- expose IdP‑initiated auth config routes unconditionally
- adjust unit tests

## Testing
- `pnpm -r lint` *(fails: ESLint couldn't find config)*
- `pnpm -r --parallel --workspace-concurrency=0 test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c59ffc648832fb3c3a0fb2e515089