### PR TITLE
Move WebAuthn option generators to shared util

### DIFF
--- a/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
@@ -15,11 +15,13 @@ import { type PublicKeyCredentialRequestOptionsJSON } from 'node_modules/@simple
 
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import {
-  generateWebAuthnAuthenticationOptions,
-  generateWebAuthnRegistrationOptions,
   verifyWebAuthnAuthentication,
   verifyWebAuthnRegistration,
 } from '#src/routes/interaction/utils/webauthn.js';
+import {
+  generateWebAuthnAuthenticationOptions,
+  generateWebAuthnRegistrationOptions,
+} from '#src/routes/interaction/utils/webauthn-options.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';

--- a/packages/core/src/routes/interaction/additional.test.ts
+++ b/packages/core/src/routes/interaction/additional.test.ts
@@ -56,7 +56,7 @@ const { sendVerificationCodeToIdentifier } = await mockEsmWithActual(
 );
 
 const { generateWebAuthnRegistrationOptions, generateWebAuthnAuthenticationOptions } =
-  await mockEsmWithActual('./utils/webauthn.js', () => ({
+  await mockEsmWithActual('./utils/webauthn-options.js', () => ({
     generateWebAuthnRegistrationOptions: jest
       .fn()
       .mockResolvedValue(mockWebAuthnRegistrationOptions),

--- a/packages/core/src/routes/interaction/additional.ts
+++ b/packages/core/src/routes/interaction/additional.ts
@@ -41,7 +41,7 @@ import { sendVerificationCodeToIdentifier } from './utils/verification-code-vali
 import {
   generateWebAuthnAuthenticationOptions,
   generateWebAuthnRegistrationOptions,
-} from './utils/webauthn.js';
+} from './utils/webauthn-options.js';
 import { verifyIdentifier } from './verifications/index.js';
 import verifyProfile from './verifications/profile-verification.js';
 

--- a/packages/core/src/routes/interaction/utils/webauthn-options.ts
+++ b/packages/core/src/routes/interaction/utils/webauthn-options.ts
@@ -1,0 +1,88 @@
+import {
+  MfaFactor,
+  type MfaVerificationWebAuthn,
+  type MfaVerifications,
+  type User,
+  type WebAuthnRegistrationOptions,
+} from '@logto/schemas';
+import { getUserDisplayName } from '@logto/shared';
+import {
+  type GenerateRegistrationOptionsOpts,
+  generateRegistrationOptions,
+  type GenerateAuthenticationOptionsOpts,
+  generateAuthenticationOptions,
+} from '@simplewebauthn/server';
+
+import RequestError from '#src/errors/RequestError/index.js';
+
+export type GenerateWebAuthnRegistrationOptionsParameters = {
+  rpId: string;
+  user: Pick<
+    User,
+    'id' | 'name' | 'username' | 'primaryEmail' | 'primaryPhone' | 'mfaVerifications'
+  >;
+};
+
+export const generateWebAuthnRegistrationOptions = async ({
+  rpId,
+  user,
+}: GenerateWebAuthnRegistrationOptionsParameters): Promise<WebAuthnRegistrationOptions> => {
+  const { username, name, primaryEmail, primaryPhone, id, mfaVerifications } = user;
+
+  const options: GenerateRegistrationOptionsOpts = {
+    rpName: rpId,
+    rpID: rpId,
+    userID: Uint8Array.from(Buffer.from(id)),
+    userName: getUserDisplayName({ username, primaryEmail, primaryPhone }) ?? 'Unnamed User',
+    userDisplayName:
+      getUserDisplayName({ name, username, primaryEmail, primaryPhone }) ?? 'Unnamed User',
+    timeout: 60_000,
+    attestationType: 'none',
+    excludeCredentials: mfaVerifications
+      .filter(
+        (verification): verification is MfaVerificationWebAuthn =>
+          verification.type === MfaFactor.WebAuthn
+      )
+      .map(({ credentialId, transports }) => ({
+        id: credentialId,
+        type: 'public-key',
+        transports,
+      })),
+    authenticatorSelection: {
+      residentKey: 'discouraged',
+    },
+    // Values for COSEALG.ES256, COSEALG.RS256, Node.js don't have those enums
+    supportedAlgorithmIDs: [-7, -257],
+  };
+
+  return generateRegistrationOptions(options);
+};
+
+export const generateWebAuthnAuthenticationOptions = async ({
+  rpId,
+  mfaVerifications,
+}: {
+  rpId: string;
+  mfaVerifications: MfaVerifications;
+}) => {
+  const webAuthnVerifications = mfaVerifications.filter(
+    (verification): verification is MfaVerificationWebAuthn =>
+      verification.type === MfaFactor.WebAuthn
+  );
+
+  if (webAuthnVerifications.length === 0) {
+    throw new RequestError('session.mfa.webauthn_verification_not_found');
+  }
+
+  const options: GenerateAuthenticationOptionsOpts = {
+    timeout: 60_000,
+    allowCredentials: webAuthnVerifications.map(({ credentialId, transports }) => ({
+      id: credentialId,
+      type: 'public-key',
+      transports,
+    })),
+    userVerification: 'required',
+    rpID: rpId,
+  };
+  return generateAuthenticationOptions(options);
+};

--- a/packages/core/src/routes/interaction/utils/webauthn.test.ts
+++ b/packages/core/src/routes/interaction/utils/webauthn.test.ts
@@ -32,12 +32,9 @@ const {
     .mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 1 } }),
 }));
 
-const {
-  generateWebAuthnRegistrationOptions,
-  verifyWebAuthnRegistration,
-  generateWebAuthnAuthenticationOptions,
-  verifyWebAuthnAuthentication,
-} = await import('./webauthn.js');
+const { generateWebAuthnRegistrationOptions, generateWebAuthnAuthenticationOptions } =
+  await import('./webauthn-options.js');
+const { verifyWebAuthnRegistration, verifyWebAuthnAuthentication } = await import('./webauthn.js');
 
 const rpId = 'logto.io';
 const origin = 'https://logto.io';

--- a/packages/core/src/routes/interaction/utils/webauthn.ts
+++ b/packages/core/src/routes/interaction/utils/webauthn.ts
@@ -2,69 +2,19 @@ import {
   type BindWebAuthnPayload,
   MfaFactor,
   type MfaVerificationWebAuthn,
-  type User,
-  type WebAuthnRegistrationOptions,
   type MfaVerifications,
   type WebAuthnVerificationPayload,
   type VerifyMfaResult,
 } from '@logto/schemas';
-import { getUserDisplayName } from '@logto/shared';
 import {
-  type GenerateRegistrationOptionsOpts,
-  generateRegistrationOptions,
   verifyRegistrationResponse,
   type VerifyRegistrationResponseOpts,
-  type GenerateAuthenticationOptionsOpts,
-  generateAuthenticationOptions,
-  type VerifyAuthenticationResponseOpts,
   verifyAuthenticationResponse,
+  type VerifyAuthenticationResponseOpts,
 } from '@simplewebauthn/server';
 import { isoBase64URL } from '@simplewebauthn/server/helpers';
 
 import RequestError from '#src/errors/RequestError/index.js';
-
-type GenerateWebAuthnRegistrationOptionsParameters = {
-  rpId: string;
-  user: Pick<
-    User,
-    'id' | 'name' | 'username' | 'primaryEmail' | 'primaryPhone' | 'mfaVerifications'
-  >;
-};
-
-export const generateWebAuthnRegistrationOptions = async ({
-  rpId,
-  user,
-}: GenerateWebAuthnRegistrationOptionsParameters): Promise<WebAuthnRegistrationOptions> => {
-  const { username, name, primaryEmail, primaryPhone, id, mfaVerifications } = user;
-
-  const options: GenerateRegistrationOptionsOpts = {
-    rpName: rpId,
-    rpID: rpId,
-    userID: Uint8Array.from(Buffer.from(id)),
-    userName: getUserDisplayName({ username, primaryEmail, primaryPhone }) ?? 'Unnamed User',
-    userDisplayName:
-      getUserDisplayName({ name, username, primaryEmail, primaryPhone }) ?? 'Unnamed User',
-    timeout: 60_000,
-    attestationType: 'none',
-    excludeCredentials: mfaVerifications
-      .filter(
-        (verification): verification is MfaVerificationWebAuthn =>
-          verification.type === MfaFactor.WebAuthn
-      )
-      .map(({ credentialId, transports }) => ({
-        id: credentialId,
-        type: 'public-key',
-        transports,
-      })),
-    authenticatorSelection: {
-      residentKey: 'discouraged',
-    },
-    // Values for COSEALG.ES256, COSEALG.RS256, Node.js don't have those enums
-    supportedAlgorithmIDs: [-7, -257],
-  };
-
-  return generateRegistrationOptions(options);
-};
 
 export const verifyWebAuthnRegistration = async (
   payload: Omit<BindWebAuthnPayload, 'type'>,
@@ -91,34 +41,6 @@ export const verifyWebAuthnRegistration = async (
   }
 };
 
-export const generateWebAuthnAuthenticationOptions = async ({
-  rpId,
-  mfaVerifications,
-}: {
-  rpId: string;
-  mfaVerifications: MfaVerifications;
-}) => {
-  const webAuthnVerifications = mfaVerifications.filter(
-    (verification): verification is MfaVerificationWebAuthn =>
-      verification.type === MfaFactor.WebAuthn
-  );
-
-  if (webAuthnVerifications.length === 0) {
-    throw new RequestError('session.mfa.webauthn_verification_not_found');
-  }
-
-  const options: GenerateAuthenticationOptionsOpts = {
-    timeout: 60_000,
-    allowCredentials: webAuthnVerifications.map(({ credentialId, transports }) => ({
-      id: credentialId,
-      type: 'public-key',
-      transports,
-    })),
-    userVerification: 'required',
-    rpID: rpId,
-  };
-  return generateAuthenticationOptions(options);
-};
 
 type VerifyWebAuthnAuthenticationParameters = {
   payload: Omit<WebAuthnVerificationPayload, 'type'>;


### PR DESCRIPTION
## Summary
- create `webauthn-options` util for generating registration and authentication options
- update imports in WebAuthn verification classes and related tests
- keep verification helpers in existing `webauthn` util

## Testing
- `pnpm -r lint` *(fails: ESLint config missing)*
- `pnpm -r test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a0916e8832fa24eee64a2e7fac1