### PR TITLE
Fix cloud connection endpoint

### DIFF
--- a/packages/core/src/__mocks__/cloud-connection.ts
+++ b/packages/core/src/__mocks__/cloud-connection.ts
@@ -8,7 +8,7 @@ export const mockGetCloudConnectionData: CloudConnectionLibrary['getCloudConnect
     resource: 'https://logto.dev',
     appId: 'appId',
     appSecret: 'appSecret',
-    endpoint: 'https://logto.dev/api',
+    endpoint: 'https://logto.dev',
     tokenEndpoint: 'https://logto.dev/oidc/token',
   });
 

--- a/packages/core/src/libraries/cloud-connection.ts
+++ b/packages/core/src/libraries/cloud-connection.ts
@@ -52,7 +52,7 @@ export class CloudConnectionLibrary {
     return {
       ...credentials,
       tokenEndpoint: appendPath(adminUrlSet.endpoint, 'oidc/token').toString(),
-      endpoint: appendPath(cloudUrlSet.endpoint, 'api').toString(),
+      endpoint: cloudUrlSet.endpoint.toString(),
     };
   };
 
@@ -114,8 +114,7 @@ export class CloudConnectionLibrary {
       const { endpoint } = await this.getCloudConnectionData();
 
       this.client = new Client<typeof router>({
-        // TODO @sijie @darcy remove the 'api' appending in getCloudConnectionData()
-        baseUrl: endpoint.replace('/api', ''),
+        baseUrl: endpoint,
         headers: async () => {
           return { Authorization: `Bearer ${await this.getAccessToken()}` };
         },


### PR DESCRIPTION
## Summary
- return cloud endpoint without `/api` suffix
- use the endpoint directly when creating the client
- update mock data for tests

## Testing
- `pnpm -r --parallel --workspace-concurrency=0 test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a220c50832fa2a953c62eb499e6