### PR TITLE
Handle conflict with 422 status

### DIFF
--- a/packages/core/src/utils/SchemaRouter.test.ts
+++ b/packages/core/src/utils/SchemaRouter.test.ts
@@ -95,6 +95,15 @@ describe('SchemaRouter', () => {
 
       expect(response.status).toEqual(400);
     });
+
+    it('should throw when entity already exists', async () => {
+      const error = new RequestError({ code: 'entity.unique_integrity_violation', status: 422 });
+      jest.spyOn(queries, 'insert').mockRejectedValueOnce(error);
+
+      const response = await request.post(baseRoute).send({});
+
+      expect(response.status).toEqual(422);
+    });
   });
 
   describe('getById', () => {
@@ -120,6 +129,15 @@ describe('SchemaRouter', () => {
       expect(queries.updateById).toHaveBeenCalledWith('test', { name: 'test_new' });
       expect(response.body).toStrictEqual({ id: 'test', name: 'test_new' });
       expect(response.status).toEqual(200);
+    });
+
+    it('should throw when patched entity conflicts', async () => {
+      const error = new RequestError({ code: 'entity.unique_integrity_violation', status: 422 });
+      jest.spyOn(queries, 'updateById').mockRejectedValueOnce(error);
+
+      const response = await request.patch(`${baseRoute}/test`).send({ name: 'conflict' });
+
+      expect(response.status).toEqual(422);
     });
   });
 

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -383,7 +383,7 @@ export default class SchemaRouter<
           // @ts-expect-error -- `.omit()` doesn't play well with generics
           body: schema.createGuard.omit({ id: true }),
           response: entityGuard ?? schema.guard,
-          status: [201], // TODO: 409/422 for conflict?
+          status: [201, 422],
         }),
         this.#ensembleQualifiedMiddlewares('post'),
         async (ctx, next) => {
@@ -421,7 +421,7 @@ export default class SchemaRouter<
           params: z.object({ id: z.string().min(1) }),
           body: schema.updateGuard,
           response: entityGuard ?? schema.guard,
-          status: [200, 404], // TODO: 409/422 for conflict?
+          status: [200, 404, 422],
         }),
         this.#ensembleQualifiedMiddlewares('patch'),
         async (ctx, next) => {


### PR DESCRIPTION
## Summary
- respond with HTTP 422 on create/patch conflicts
- cover conflict scenarios in schema router tests

## Testing
- `pnpm -r --parallel --workspace-concurrency=0 test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a2ab58c832f9b139efbcfd9bd5c