### PR TITLE
Remove unused Markdown workaround

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -91,7 +91,6 @@
     "prettier": "^3.5.3",
     "prism-react-renderer": "^2.4.1",
     "prop-types": "^15.8.1",
-    "property-information": "^6.2.0",
     "react": "^18.3.1",
     "react-animate-height": "^3.0.4",
     "react-color-palette": "^7.2.1",

--- a/packages/console/src/components/Markdown/index.tsx
+++ b/packages/console/src/components/Markdown/index.tsx
@@ -5,16 +5,6 @@ import { memo, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-// TODO: @charles double check if this is still needed
-/**
- * Workaround for the markdown crash issue in the parcel dev build. It seems parcel does
- * something clever in dev mode and messing up the `hastToReact` module. Manually adding
- * the `property-information` import somehow keeps the reference and makes dev build work.
- * @see https://github.com/remarkjs/react-markdown/issues/747
- * @see https://github.com/parcel-bundler/parcel/discussions/9113
- */
-// eslint-disable-next-line import/no-unassigned-import
-import 'property-information';
 
 import CodeEditor from '@/ds-components/CodeEditor';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3409,9 +3409,6 @@ importers:
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
-      property-information:
-        specifier: ^6.2.0
-        version: 6.2.0
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Summary
- remove `property-information` workaround from the Markdown component
- drop `property-information` from console dependencies

## Testing
- `pnpm ci:test` *(fails: vitest not found)*
- `pnpm --filter ./packages/console lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a3753b8832f967b96696a60ff0d