### PR TITLE
Fix SAML guide drawer

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/GuideDrawer/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/GuideDrawer/index.tsx
@@ -1,4 +1,4 @@
-import { ApplicationType, type ApplicationResponse } from '@logto/schemas';
+import { type ApplicationResponse } from '@logto/schemas';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -26,11 +26,7 @@ function GuideDrawer({ app, secrets, onClose }: Props) {
   const { getStructuredAppGuideMetadata } = useAppGuideMetadata();
   const [selectedGuide, setSelectedGuide] = useState<SelectedGuide>();
 
-  const appType = useMemo(
-    // TODO: @darcy Revisit this section during the implementation of the SAML app guide, note that SAML is currently treated as a Traditional app to prevent TypeScript errors (this is actually feasible since the API for creating SAML apps has not yet been enabled). However, SAML apps cannot modify OIDC config, so the final guide may differ.
-    () => (app.type === ApplicationType.SAML ? ApplicationType.Traditional : app.type),
-    [app.type]
-  );
+  const appType = useMemo(() => app.type, [app.type]);
 
   const structuredMetadata = useMemo(
     () => getStructuredAppGuideMetadata({ categories: [appType] }),

--- a/packages/console/src/pages/ApplicationDetails/components/AppGuide/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/AppGuide/index.tsx
@@ -32,8 +32,8 @@ function AppGuide({ className, guideId, app, secrets, isCompact, onClose }: Prop
           app,
           secrets,
           endpoint: applyCustomDomain(tenantEndpoint?.href ?? ''),
-          redirectUris: app.oidcClientMetadata.redirectUris,
-          postLogoutRedirectUris: app.oidcClientMetadata.postLogoutRedirectUris,
+          redirectUris: app.oidcClientMetadata?.redirectUris,
+          postLogoutRedirectUris: app.oidcClientMetadata?.postLogoutRedirectUris,
           isCompact: Boolean(isCompact),
         }
       ) satisfies GuideContextType | undefined,


### PR DESCRIPTION
## Summary
- adjust guide drawer to respect application type directly
- support optional SAML fields in AppGuide

## Testing
- `pnpm ci:lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm ci:stylelint` *(fails: stylelint not found)*
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a450e78832fbf6cf250107339cb