### PR TITLE
Move SSO types to schemas package

### DIFF
--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcConnectorForm.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcConnectorForm.tsx
@@ -17,7 +17,7 @@ import {
   type OidcConnectorConfig,
   oidcConnectorConfigGuard,
   oidcProviderConfigGuard,
-} from '../types/oidc';
+} from '@logto/schemas';
 
 import OidcMetadataForm from './OidcMetadataForm';
 import OidcConnectorSpInfo from './ServiceProviderInfo/OidcConnectorSpInfo';

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcMetadataForm/ParsedConfigPreview/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcMetadataForm/ParsedConfigPreview/index.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import { type OidcProviderConfig } from '@/pages/EnterpriseSsoDetails/types/oidc';
+import { type OidcProviderConfig } from '@logto/schemas';
 
 import styles from './index.module.scss';
 

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcMetadataForm/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcMetadataForm/index.tsx
@@ -9,7 +9,7 @@ import Switch from '@/ds-components/Switch';
 import TextInput from '@/ds-components/TextInput';
 import { uriValidator } from '@/utils/validator';
 
-import { type OidcConnectorConfig, type OidcProviderConfig } from '../../types/oidc';
+import { type OidcConnectorConfig, type OidcProviderConfig } from '@logto/schemas';
 
 import ParsedConfigPreview from './ParsedConfigPreview';
 import styles from './index.module.scss';

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlAttributeMapping/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlAttributeMapping/index.tsx
@@ -8,7 +8,7 @@ import {
   samlAttributeKeys,
   type SamlProviderConfig,
   type SamlConnectorConfig,
-} from '@/pages/EnterpriseSsoDetails/types/saml';
+} from '@logto/schemas';
 
 import styles from './index.module.scss';
 

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlConnectorForm.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlConnectorForm.tsx
@@ -16,7 +16,7 @@ import {
   samlProviderConfigGuard,
   type SamlConnectorConfig,
   type SamlSsoConnectorWithProviderConfig,
-} from '@/pages/EnterpriseSsoDetails/types/saml';
+} from '@logto/schemas';
 import { trySubmitSafe } from '@/utils/form';
 
 import { invalidConfigErrorCode, invalidMetadataErrorCode } from '../config';

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlMetadataForm/ParsedConfigPreview/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlMetadataForm/ParsedConfigPreview/index.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
 import DynamicT from '@/ds-components/DynamicT';
-import { type SamlProviderConfig } from '@/pages/EnterpriseSsoDetails/types/saml';
+import { type SamlProviderConfig } from '@logto/schemas';
 
 import styles from './index.module.scss';
 

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlMetadataForm/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlMetadataForm/index.tsx
@@ -8,7 +8,7 @@ import TextInput from '@/ds-components/TextInput';
 import {
   type SamlConnectorConfig,
   type SamlProviderConfig,
-} from '@/pages/EnterpriseSsoDetails/types/saml';
+} from '@logto/schemas';
 import { uriValidator } from '@/utils/validator';
 
 import FileReader, { type Props as FileReaderProps } from '../FileReader';

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/ServiceProviderInfo/SamlConnectorSpInfo.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/ServiceProviderInfo/SamlConnectorSpInfo.tsx
@@ -4,7 +4,7 @@ import CopyToClipboard from '@/ds-components/CopyToClipboard';
 import FormField from '@/ds-components/FormField';
 import useCustomDomain from '@/hooks/use-custom-domain';
 
-import { type SamlProviderConfig } from '../../types/saml';
+import { type SamlProviderConfig } from '@logto/schemas';
 
 type Props = {
   readonly samlProviderConfig?: SamlProviderConfig;

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/index.tsx
@@ -1,7 +1,9 @@
 import { SsoProviderType, type SsoConnectorWithProviderConfig } from '@logto/schemas';
 
-import { type OidcSsoConnectorWithProviderConfig } from '../types/oidc';
-import { type SamlSsoConnectorWithProviderConfig } from '../types/saml';
+import {
+  type OidcSsoConnectorWithProviderConfig,
+  type SamlSsoConnectorWithProviderConfig,
+} from '@logto/schemas';
 
 import OidcConnectorForm from './OidcConnectorForm';
 import SamlConnectorForm from './SamlConnectorForm';

--- a/packages/schemas/src/types/index.ts
+++ b/packages/schemas/src/types/index.ts
@@ -33,3 +33,5 @@ export * from './ssr.js';
 export * from './saml-application.js';
 export * from './verification-records/index.js';
 export * from './custom-profile-fields.js';
+export * from './oidc.js';
+export * from './saml.js';

--- a/packages/schemas/src/types/oidc.ts
+++ b/packages/schemas/src/types/oidc.ts
@@ -1,18 +1,9 @@
-import { type SsoProviderType, type SsoConnectorWithProviderConfig } from '@logto/schemas';
+import { type SsoProviderType, type SsoConnectorWithProviderConfig } from './sso-connector.js';
 import { z } from 'zod';
 
-/* Oidc Connectors */
-export type OidcSsoConnectorWithProviderConfig = Omit<
-  SsoConnectorWithProviderConfig,
-  'providerType'
-> & {
+export type OidcSsoConnectorWithProviderConfig = Omit<SsoConnectorWithProviderConfig, 'providerType'> & {
   providerType: SsoProviderType.OIDC;
 };
-
-/**
- * All the following guards are copied from {@link @logto/core/packages/core/src/sso/types/oidc }
- * @TODO: consider to move them to a shared package e.g. @logto/schemas
- */
 
 export const oidcConnectorConfigGuard = z
   .object({

--- a/packages/schemas/src/types/saml.ts
+++ b/packages/schemas/src/types/saml.ts
@@ -1,18 +1,10 @@
-import { type SsoConnectorWithProviderConfig, type SsoProviderType } from '@logto/schemas';
+import { type SsoConnectorWithProviderConfig, type SsoProviderType } from './sso-connector.js';
 import { z } from 'zod';
 
-/* Saml Connectors */
-export type SamlSsoConnectorWithProviderConfig = Omit<
-  SsoConnectorWithProviderConfig,
-  'providerType'
-> & {
+export type SamlSsoConnectorWithProviderConfig = Omit<SsoConnectorWithProviderConfig, 'providerType'> & {
   providerType: SsoProviderType.SAML;
 };
 
-/**
- * All the following guards are copied from {@link @logto/core/packages/core/src/sso/types/saml }
- * @TODO: consider to move them to a shared package e.g. @logto/schemas
- */
 const samlAttributeMappingGuard = z
   .object({
     id: z.string(),
@@ -27,7 +19,6 @@ export const samlAttributeKeys = Object.freeze(['id', 'email', 'name']) satisfie
   keyof SamlAttributeMapping
 >;
 
-// Guard the saml connector config data from the response of the API.
 export const samlConnectorConfigGuard = z
   .object({
     metadataUrl: z.string(),
@@ -41,7 +32,6 @@ export const samlConnectorConfigGuard = z
 
 export type SamlConnectorConfig = z.infer<typeof samlConnectorConfigGuard>;
 
-// Guard the saml provider config from the response of the API.
 const samlServiceProviderMetadataGuard = z.object({
   entityId: z.string().min(1),
   assertionConsumerServiceUrl: z.string().min(1),


### PR DESCRIPTION
## Summary
- move enterprise SSO OIDC/SAML types into `@logto/schemas`
- update console imports after moving types

## Testing
- `pnpm ci:test` *(fails: node modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a554140832f872ba5ef02645581