### PR TITLE
Fix OIDC error handler message

### DIFF
--- a/packages/core/src/middleware/koa-oidc-error-handler.test.ts
+++ b/packages/core/src/middleware/koa-oidc-error-handler.test.ts
@@ -21,7 +21,7 @@ describe('koaOidcErrorHandler middleware', () => {
       throw error;
     });
 
-    const out = errorOut(error);
+    const out = errorOut(error, i18next);
     const code = `oidc.${out.error}`;
     await koaOidcErrorHandler()(ctx, next);
     expect(ctx.status).toBe(error.statusCode);

--- a/packages/core/src/middleware/koa-oidc-error-handler.ts
+++ b/packages/core/src/middleware/koa-oidc-error-handler.ts
@@ -25,12 +25,15 @@ const errorUris: Record<string, string> = Object.freeze({
  *
  * @see {@link https://github.com/panva/node-oidc-provider/blob/37d0a6cfb3c618141a44cbb904ce45659438f821/lib/helpers/err_out.js | oidc-provider/lib/helpers/err_out.js}
  */
-export const errorOut = ({
-  expose,
-  message,
-  error_description: description,
-  ...rest
-}: errors.OIDCProviderError) => {
+export const errorOut = (
+  {
+    expose,
+    message,
+    error_description: description,
+    ...rest
+  }: errors.OIDCProviderError,
+  i18n: WithI18nContext['i18n']
+) => {
   if (expose) {
     return {
       error: message,
@@ -43,7 +46,7 @@ export const errorOut = ({
 
   return {
     error: 'server_error',
-    error_description: 'oops! something went wrong',
+    error_description: i18n.t('errors:oidc.server_error'),
   };
 };
 
@@ -98,7 +101,7 @@ export default function koaOidcErrorHandler<StateT, ContextT extends WithI18nCon
       // Mimic oidc-provider's error handling, thus we can use the unified logic below.
       // See https://github.com/panva/node-oidc-provider/blob/37d0a6cfb3c618141a44cbb904ce45659438f821/lib/shared/error_handler.js
       ctx.status = error.statusCode || 500;
-      ctx.body = errorOut(error);
+      ctx.body = errorOut(error, ctx.i18n);
 
       // Track the original error in App Insights.
       void appInsights.trackException(error, buildAppInsightsTelemetry(ctx));


### PR DESCRIPTION
## Summary
- replace placeholder error message in OIDC error handler
- update tests accordingly

## Testing
- `pnpm -r --parallel --workspace-concurrency=0 test:ci` *(fails: vitest not found)*
- `pnpm -r --parallel --workspace-concurrency=0 lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a5ac3a4832fbe542481282f8097