### PR TITLE
Fix CopyToClipboard margin

### DIFF
--- a/packages/console/src/ds-components/CopyToClipboard/index.module.scss
+++ b/packages/console/src/ds-components/CopyToClipboard/index.module.scss
@@ -71,4 +71,14 @@
   .dot {
     -webkit-text-stroke: 1px var(--color-text);
   }
+
+  .copyToolTipAnchor {
+    margin-inline-start: _.unit(2);
+  }
+
+  &.icon {
+    .copyToolTipAnchor {
+      margin-inline-start: 0;
+    }
+  }
 }

--- a/packages/console/src/ds-components/CopyToClipboard/index.tsx
+++ b/packages/console/src/ds-components/CopyToClipboard/index.tsx
@@ -113,7 +113,10 @@ function CopyToClipboard(
           </div>
         )}
         {hasVisibilityToggle && (
-          <Tooltip content={t(showHiddenContent ? 'hide' : 'view')}>
+          <Tooltip
+            content={t(showHiddenContent ? 'hide' : 'view')}
+            anchorClassName={styles.copyToolTipAnchor}
+          >
             <IconButton
               className={styles.iconButton}
               iconClassName={styles.icon}
@@ -124,7 +127,11 @@ function CopyToClipboard(
             </IconButton>
           </Tooltip>
         )}
-        <Tooltip isSuccessful={copyState === 'copied'} content={t(copyState)}>
+        <Tooltip
+          isSuccessful={copyState === 'copied'}
+          content={t(copyState)}
+          anchorClassName={styles.copyToolTipAnchor}
+        >
           <IconButton
             ref={copyIconReference}
             className={styles.iconButton}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.module.scss
@@ -63,10 +63,6 @@
           background: var(--color-overlay-dark-bg-pressed);
         }
 
-        // TODO (LOG-8602): Remove the default left margin of CopyToClipboard copyToolTipAnchor component.
-        div[class*='copyToolTipAnchor'] {
-          margin-inline-start: 0;
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- style `CopyToClipboard` tooltip anchor
- pass anchor class to tooltips
- remove margin hack from MonacoCodeEditor SCSS

## Testing
- `pnpm -r --parallel --workspace-concurrency=0 lint` *(fails: eslint not found)*
- `pnpm -r --parallel --workspace-concurrency=0 stylelint` *(fails: stylelint not found)*
- `pnpm -r --parallel --workspace-concurrency=0 test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5f647554832f81efeae84926367e