### PR TITLE
Fix useApi unauthorized handling

### DIFF
--- a/packages/console/src/hooks/use-api.ts
+++ b/packages/console/src/hooks/use-api.ts
@@ -59,12 +59,7 @@ const useGlobalRequestErrorHandler = (toastDisabledErrorCodes?: LogtoErrorCode[]
         // Clone the response to avoid "Response body is already used".
         const data = await response.clone().json<RequestErrorBody>();
 
-        // This is what will happen when the user still has the legacy refresh token without
-        // organization scope. We should sign them out and redirect to the sign in page.
-        // TODO: This is a temporary solution to prevent the user from getting stuck in Console,
-        // which can be removed after all legacy refresh tokens are expired, i.e. after Jan 10th,
-        // 2024.
-        if (response.status === 403 && data.message === 'Insufficient permissions.') {
+        if (data.code === 'auth.unauthorized') {
           await signOut(postSignOutRedirectUri.href);
           return;
         }


### PR DESCRIPTION
## Summary
- handle unauthorized errors directly in useApi
- remove old workaround for legacy refresh tokens

## Testing
- `pnpm ci:lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm ci:stylelint` *(fails: stylelint: not found)*
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a562f64832f8273d617dffea32e