### PR TITLE
Reintroduce COEP header

### DIFF
--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -76,10 +76,8 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
   const basicSecurityHeaderSettings: HelmetOptions = {
     contentSecurityPolicy: false, // Exclusively set per app
     crossOriginOpenerPolicy: false, // Allow cross origin opener, as some apps rely on popup window for the sign-in flow
-    // Google One Tap iframe request does not respond the proper CORP header (it uses `same-site` instead of `cross-origin`)
-    // and we cannot add the `crossorigin` attribute to the iframe, so the only solution is to disable the COEP header here.
-    // TODO: Re-enable COEP header when Google One Tap supports CORP header.
-    crossOriginEmbedderPolicy: false,
+    // Google One Tap iframe previously responded with an incorrect CORP header.
+    // TODO: Monitor Google One Tap for CORP support.
     dnsPrefetchControl: false,
     referrerPolicy: {
       policy: 'strict-origin-when-cross-origin',


### PR DESCRIPTION
## Summary
- remove `crossOriginEmbedderPolicy: false` override
- document monitoring Google One Tap for CORP support

## Testing
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c59e27518832f878a06d669c3fc4a