### PR TITLE
Improve token revocation logging

### DIFF
--- a/packages/core/src/event-listeners/grant.ts
+++ b/packages/core/src/event-listeners/grant.ts
@@ -44,16 +44,10 @@ export const grantRevocationListener = (
   ctx: KoaContextWithOIDC & WithLogContext,
   grantId: string
 ) => {
-  const {
-    entities: { AccessToken, RefreshToken },
-  } = ctx.oidc;
-
-  // TODO: Check if this is needed or just use `Account?.accountId`
-  const userId = AccessToken?.accountId ?? RefreshToken?.accountId;
   const tokenTypes = getRevocationTokenTypes(ctx.oidc);
 
   const log = ctx.createLog('RevokeToken');
-  log.append({ ...extractInteractionContext(ctx), userId, grantId, tokenTypes });
+  log.append({ ...extractInteractionContext(ctx), grantId, tokenTypes });
 };
 
 /**

--- a/packages/core/src/event-listeners/utils.ts
+++ b/packages/core/src/event-listeners/utils.ts
@@ -8,7 +8,7 @@ export const extractInteractionContext = (
   ctx: IRouterParamContext & KoaContextWithOIDC & WithAppSecretContext
 ): LogPayload => {
   const {
-    entities: { Account, Session, Client, Interaction },
+    entities: { Account, Session, Client, Interaction, AccessToken, RefreshToken },
     params,
   } = ctx.oidc;
 
@@ -17,7 +17,7 @@ export const extractInteractionContext = (
     applicationSecret: ctx.appSecret,
     sessionId: Session?.jti,
     interactionId: Interaction?.jti,
-    userId: Account?.accountId,
+    userId: Account?.accountId ?? AccessToken?.accountId ?? RefreshToken?.accountId,
     params,
   };
 };


### PR DESCRIPTION
## Summary
- simplify grantRevocationListener
- include AccessToken or RefreshToken accountId in log context extraction

## Testing
- `pnpm -r lint` *(fails: ESLint couldn't find configuration files)*
- `pnpm -r test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c59f30fd0832f94a80e25ea71262f