### PR TITLE
Sanitize user profile in extra token claims

### DIFF
--- a/packages/core/src/oidc/extra-token-claims.test.ts
+++ b/packages/core/src/oidc/extra-token-claims.test.ts
@@ -1,0 +1,18 @@
+import { userProfileJsonGuard } from './extra-token-claims.js';
+
+describe('userProfileJsonGuard', () => {
+  it('should strip undefined fields', () => {
+    const profile = {
+      familyName: 'Smith',
+      givenName: undefined,
+      address: { country: 'US', region: undefined },
+    } as unknown;
+
+    const result = userProfileJsonGuard.parse(profile);
+
+    expect(result).toEqual({
+      familyName: 'Smith',
+      address: { country: 'US' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize user profile when building JWT customization context
- export guard to cast user profile to Json
- add tests for userProfileJsonGuard

## Testing
- `pnpm --filter @logto/core test` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684c59f62b2c832fa3299c6b056fb1bd