### PR TITLE
Export googleIssuer constant

### DIFF
--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcMetadataForm/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcMetadataForm/index.tsx
@@ -10,6 +10,7 @@ import TextInput from '@/ds-components/TextInput';
 import { uriValidator } from '@/utils/validator';
 
 import { type OidcConnectorConfig, type OidcProviderConfig } from '../../types/oidc';
+import { googleIssuer } from '../../../../../../core/src/sso/GoogleWorkspaceSsoConnector';
 
 import ParsedConfigPreview from './ParsedConfigPreview';
 import styles from './index.module.scss';
@@ -56,14 +57,13 @@ function OidcMetadataForm({ providerConfig, config, providerName }: Props) {
         isRequired={providerName !== SsoProviderName.GOOGLE_WORKSPACE}
         title="enterprise_sso.metadata.oidc.issuer_field_name"
       >
-        {providerName === SsoProviderName.GOOGLE_WORKSPACE ? (
+          {providerName === SsoProviderName.GOOGLE_WORKSPACE ? (
           <CopyToClipboard
             displayType="block"
             variant="border"
-            // TODO: this hard-coded value should align with the `googleIssuer` value defined in `packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts`.
-            value={providerConfig?.issuer ?? 'https://accounts.google.com'}
+            value={providerConfig?.issuer ?? googleIssuer}
           />
-        ) : (
+          ) : (
           <TextInput
             {...register('issuer', {
               required: true,

--- a/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
+++ b/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
@@ -7,8 +7,8 @@ import { type SingleSignOn, type SingleSignOnConnectorData } from '../types/conn
 import { basicOidcConnectorConfigGuard } from '../types/oidc.js';
 import { type CreateSingleSignOnSession } from '../types/session.js';
 
-// Google use static issue endpoint.
-const googleIssuer = 'https://accounts.google.com';
+// Google uses a static issuer endpoint.
+export const googleIssuer = 'https://accounts.google.com';
 
 export class GoogleWorkspaceSsoConnector extends OidcConnector implements SingleSignOn {
   static googleIssuer = googleIssuer;

--- a/packages/core/src/sso/index.ts
+++ b/packages/core/src/sso/index.ts
@@ -2,7 +2,10 @@ import { SsoProviderName } from '@logto/schemas';
 
 import { azureAdSsoConnectorFactory } from './AzureAdSsoConnector/index.js';
 import { azureOidcSsoConnectorFactory } from './AzureOidcSsoConnector/index.js';
-import { googleWorkSpaceSsoConnectorFactory } from './GoogleWorkspaceSsoConnector/index.js';
+import {
+  googleWorkSpaceSsoConnectorFactory,
+  googleIssuer,
+} from './GoogleWorkspaceSsoConnector/index.js';
 import { oidcSsoConnectorFactory } from './OidcSsoConnector/index.js';
 import { oktaSsoConnectorFactory } from './OktaSsoConnector/index.js';
 import { samlSsoConnectorFactory } from './SamlSsoConnector/index.js';
@@ -10,6 +13,7 @@ import { type SingleSignOnFactory } from './types/index.js';
 
 export { type SingleSignOnConnectorConfig, type SingleSignOnFactory } from './types/index.js';
 export * from './types/session.js';
+export { googleIssuer } from './GoogleWorkspaceSsoConnector/index.js';
 
 export const ssoConnectorFactories: {
   [key in SsoProviderName]: SingleSignOnFactory<key>;


### PR DESCRIPTION
## Summary
- export `googleIssuer` from core
- expose constant via sso index
- reuse the constant in console OIDC metadata form

## Testing
- `pnpm --filter @logto/core lint` *(fails: ESLint couldn't find config)*
- `pnpm --filter @logto/console lint` *(fails: ESLint couldn't find config)*
- `pnpm --filter @logto/core test` *(fails: missing dependencies)*
- `pnpm --filter @logto/console test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a4e26b0832fa052fd9a2136d13f