### PR TITLE
Fix application filtering for IdP initiated auth

### DIFF
--- a/packages/console/src/pages/EnterpriseSsoDetails/IdpInitiatedAuth/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/IdpInitiatedAuth/index.tsx
@@ -31,11 +31,6 @@ function IdpInitiatedAuth({ ssoConnector }: Props) {
     [applicationError, applications, idpInitiatedAuthConfig, idpInitiatedAuthConfigError]
   );
 
-  const filteredApplications = useMemo(
-    () => applications?.filter(({ isThirdParty }) => !isThirdParty),
-    [applications]
-  );
-
   if (isLoading) {
     return (
       <FormCard
@@ -50,7 +45,7 @@ function IdpInitiatedAuth({ ssoConnector }: Props) {
   return (
     <ConfigForm
       ssoConnector={ssoConnector}
-      applications={filteredApplications ?? []}
+      applications={applications ?? []}
       idpInitiatedAuthConfig={idpInitiatedAuthConfig}
       mutateIdpInitiatedConfig={mutate}
     />

--- a/packages/console/src/pages/EnterpriseSsoDetails/IdpInitiatedAuth/utils.ts
+++ b/packages/console/src/pages/EnterpriseSsoDetails/IdpInitiatedAuth/utils.ts
@@ -13,7 +13,8 @@ const applicationsSearchParams = new URLSearchParams([
   ['types', ApplicationType.Traditional],
   ['types', ApplicationType.SPA],
   ['types', ApplicationType.SAML],
-  // TODO: for now we allow all third-party applications here, including SAML and OIDC
+  // Only include first-party applications
+  ['isThirdParty', 'false'],
 ]);
 
 export const applicationsSearchUrl = `api/applications?${applicationsSearchParams.toString()}`;


### PR DESCRIPTION
## Summary
- filter application fetch by `isThirdParty=false` for IdP initiated auth
- remove redundant client-side filter

## Testing
- `pnpm -r --parallel --workspace-concurrency=0 lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm -r --parallel --workspace-concurrency=0 test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a4b2370832fbe7d98b4412723f4