### PR TITLE
Refactor grouping with Array.groupBy

### DIFF
--- a/packages/console/src/consts/webhooks.ts
+++ b/packages/console/src/consts/webhooks.ts
@@ -22,23 +22,11 @@ const dataHookEvents: DataHookEvent[] = hookEvents.filter(
   (event): event is DataHookEvent => !interactionHookEvents.includes(event as InteractionHookEvent)
 );
 
-const isDataHookSchema = (schema: string): schema is DataHookSchema =>
-  // eslint-disable-next-line no-restricted-syntax
-  Object.values(DataHookSchema).includes(schema as DataHookSchema);
 
 // Group DataHook events by schema
-// TODO: Replace this using `groupBy` once Node v22 goes LTS
-const schemaGroupedDataHookEventsMap = dataHookEvents.reduce<Map<DataHookSchema, DataHookEvent[]>>(
-  (eventGroup, event) => {
-    const [schema] = event.split('.');
-
-    if (schema && isDataHookSchema(schema)) {
-      eventGroup.set(schema, [...(eventGroup.get(schema) ?? []), event]);
-    }
-
-    return eventGroup;
-  },
-  new Map()
+const schemaGroupedDataHookEventsMap = Map.groupBy(
+  dataHookEvents,
+  (event) => event.split('.')[0] as DataHookSchema
 );
 
 // Sort the grouped `DataHook` events per console product design

--- a/packages/console/src/pages/Connectors/utils.ts
+++ b/packages/console/src/pages/Connectors/utils.ts
@@ -8,41 +8,26 @@ export const getConnectorGroups = <
 >(
   connectors: T[]
 ) => {
-  return connectors.reduce<Array<ConnectorGroup<T>>>((previous, item) => {
-    const groupIndex = previous.findIndex(
-      // Only group social connectors
-      ({ target }) => target === item.target && item.type === ConnectorType.Social
-    );
+  return Object.values(
+    Array.groupBy(connectors, (item) =>
+      item.type === ConnectorType.Social ? item.target : item.id
+    )
+  ).map((items) => {
+    const [first] = items;
 
-    if (groupIndex === -1) {
-      return [
-        ...previous,
-        {
-          id: item.id, // Take first connector's id as groupId, only used for indexing.
-          isDemo: item.isDemo,
-          name: item.name,
-          logo: item.logo,
-          logoDark: item.logoDark,
-          description: item.description,
-          target: item.target,
-          type: item.type,
-          isStandard: item.isStandard,
-          connectors: [item],
-        },
-      ];
-    }
-
-    return previous.map((group, index) => {
-      if (index !== groupIndex) {
-        return group;
-      }
-
-      return {
-        ...group,
-        connectors: [...group.connectors, item],
-      };
-    });
-  }, []);
+    return {
+      id: first.id, // Take first connector's id as groupId, only used for indexing.
+      isDemo: first.isDemo,
+      name: first.name,
+      logo: first.logo,
+      logoDark: first.logoDark,
+      description: first.description,
+      target: first.target,
+      type: first.type,
+      isStandard: first.isStandard,
+      connectors: items,
+    } as ConnectorGroup<T>;
+  });
 };
 
 export const splitMarkdownByTitle = (markdown: string) => {

--- a/packages/console/src/pages/Profile/containers/DeleteAccountModal/components/DeletionConfirmationModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/DeleteAccountModal/components/DeletionConfirmationModal/index.tsx
@@ -20,24 +20,24 @@ type RoleMap = { [key in string]?: string[] };
  * A user may have multiple roles in the same tenant.
  */
 const getRoleMap = (organizationRoles: string[]) =>
-  organizationRoles.reduce<RoleMap>((accumulator, value) => {
-    const [organizationId, roleName] = value.split(':');
+  Object.fromEntries(
+    Object.entries(
+      Array.groupBy(organizationRoles, (value) => {
+        const [organizationId, roleName] = value.split(':');
 
-    if (!organizationId || !roleName) {
-      return accumulator;
-    }
+        if (!organizationId || !roleName) {
+          return '';
+        }
 
-    const tenantId = getTenantIdFromOrganizationId(organizationId);
-
-    if (!tenantId) {
-      return accumulator;
-    }
-
-    return {
-      ...accumulator,
-      [tenantId]: [...(accumulator[tenantId] ?? []), roleName],
-    };
-  }, {});
+        return getTenantIdFromOrganizationId(organizationId) ?? '';
+      })
+    )
+      .filter(([tenantId]) => tenantId)
+      .map(([tenantId, roles]) => [
+        tenantId,
+        roles.map((role) => role.split(':')[1]),
+      ])
+  ) as RoleMap;
 
 type Props = {
   readonly onClose: () => void;

--- a/packages/core/src/libraries/application.ts
+++ b/packages/core/src/libraries/application.ts
@@ -16,16 +16,11 @@ const groupResourceScopesByResourceId = (
 ): Array<{
   resourceId: string;
   scopes: Scope[];
-}> => {
-  const resourceMap = new Map<string, Scope[]>();
-
-  for (const scope of scopes) {
-    const existingScopes = resourceMap.get(scope.resourceId) ?? [];
-    resourceMap.set(scope.resourceId, [...existingScopes, scope]);
-  }
-
-  return Array.from(resourceMap, ([resourceId, scopes]) => ({ resourceId, scopes }));
-};
+}> =>
+  Array.from(
+    Map.groupBy(scopes, ({ resourceId }) => resourceId),
+    ([resourceId, scopes]) => ({ resourceId, scopes })
+  );
 
 export const createApplicationLibrary = (queries: Queries) => {
   const {


### PR DESCRIPTION
## Summary
- replace manual Map reduction in `webhooks.ts` with `Map.groupBy`
- simplify connector grouping with `Array.groupBy`
- refactor role map generation using `Array.groupBy`
- use `Map.groupBy` for resource scope grouping

## Testing
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a3bdd78832f9f6e0f3eb78b825b