### PR TITLE
Refactor connector routing utils

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -35,10 +35,11 @@ import ConnectorTabs from './ConnectorTabs';
 import ConnectorTypeName from './ConnectorTypeName';
 import EmailUsage from './EmailUsage';
 import styles from './index.module.scss';
-
-// TODO: refactor path-related operation utils in both Connectors and ConnectorDetails page
-const getConnectorsPathname = (isSocial: boolean) =>
-  `/connectors/${isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless}`;
+import {
+  getConnectorsPathname,
+  buildGuidePathname,
+  buildDetailsPathname,
+} from '../Connectors/utils';
 
 function ConnectorDetails() {
   const { pathname } = useLocation();
@@ -193,18 +194,18 @@ function ConnectorDetails() {
                  */
                 if (connectorId === ServiceConnector.Email) {
                   const created = await createConnector({ connectorId });
-                  navigate(`/connectors/${ConnectorsTabs.Passwordless}/${created.id}`, {
+                  navigate(buildDetailsPathname(ConnectorType.Email, created.id), {
                     replace: true,
                   });
                   return;
                 }
 
-                navigate(`${getConnectorsPathname(isSocial)}/guide/${connectorId}`);
+                navigate(buildGuidePathname(data.type, connectorId));
               }
             }}
           />
           <TabNav>
-            <TabNavItem href={`${getConnectorsPathname(isSocial)}/${connectorId}`}>
+            <TabNavItem href={buildDetailsPathname(data.type, connectorId)}>
               {t('general.settings_nav')}
             </TabNavItem>
           </TabNav>

--- a/packages/console/src/pages/Connectors/index.tsx
+++ b/packages/console/src/pages/Connectors/index.tsx
@@ -40,31 +40,17 @@ import ConnectorTypeColumn from './ConnectorTypeColumn';
 import Guide from './Guide';
 import SignInExperienceSetupNotice from './SignInExperienceSetupNotice';
 import styles from './index.module.scss';
+import {
+  connectorsPathname as basePathname,
+  getTabPathname,
+  buildCreatePathname,
+  buildGuidePathname,
+  buildDetailsPathname,
+  parseToConnectorType,
+} from './utils';
 
-const basePathname = '/connectors';
-const passwordlessPathname = `${basePathname}/${ConnectorsTabs.Passwordless}`;
-const socialPathname = `${basePathname}/${ConnectorsTabs.Social}`;
-
-const buildTabPathname = (connectorType: ConnectorType) =>
-  connectorType === ConnectorType.Social ? socialPathname : passwordlessPathname;
-
-const buildCreatePathname = (connectorType: ConnectorType) => {
-  const tabPath = buildTabPathname(connectorType);
-
-  return `${tabPath}/create/${connectorType}`;
-};
-
-const buildGuidePathname = (connectorType: ConnectorType, factoryId: string) => {
-  const tabPath = buildTabPathname(connectorType);
-
-  return `${tabPath}/guide/${factoryId}`;
-};
-
-const isConnectorType = (value: string): value is ConnectorType =>
-  Object.values<string>(ConnectorType).includes(value);
-
-const parseToConnectorType = (value?: string): ConnectorType | undefined =>
-  conditional(value && isConnectorType(value) && value);
+const passwordlessPathname = getTabPathname(ConnectorsTabs.Passwordless);
+const socialPathname = getTabPathname(ConnectorsTabs.Social);
 
 function Connectors() {
   const { tab = ConnectorsTabs.Passwordless, createType, factoryId } = useParams();
@@ -178,9 +164,7 @@ function Connectors() {
 
           const { type, id } = firstConnector;
 
-          navigate(
-            `${type === ConnectorType.Social ? socialPathname : passwordlessPathname}/${id}`
-          );
+          navigate(buildDetailsPathname(type, id));
         }}
         isLoading={isLoading}
         errorMessage={error?.body?.message ?? error?.message}
@@ -219,7 +203,7 @@ function Connectors() {
              */
             if (id === ServiceConnector.Email) {
               const created = await createConnector({ connectorId: id });
-              navigate(`/connectors/${ConnectorsTabs.Passwordless}/${created.id}`, {
+              navigate(buildDetailsPathname(ConnectorType.Email, created.id), {
                 replace: true,
               });
               return;
@@ -229,13 +213,13 @@ function Connectors() {
 
             return;
           }
-          navigate(`${basePathname}/${tab}`);
+          navigate(getTabPathname(tab as ConnectorsTabs));
         }}
       />
       <Guide
         connector={connectorToShowInGuide}
         onClose={() => {
-          navigate(`${basePathname}/${tab}`);
+          navigate(getTabPathname(tab as ConnectorsTabs));
         }}
       />
     </div>

--- a/packages/console/src/pages/Connectors/utils.ts
+++ b/packages/console/src/pages/Connectors/utils.ts
@@ -1,5 +1,8 @@
 import type { ConnectorFactoryResponse, ConnectorResponse } from '@logto/schemas';
 import { ConnectorType } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+
+import { ConnectorsTabs } from '@/consts/page-tabs';
 
 import type { ConnectorGroup } from '@/types/connector';
 
@@ -55,3 +58,29 @@ export const splitMarkdownByTitle = (markdown: string) => {
     content: markdown.replace(title, ''),
   };
 };
+
+export const connectorsPathname = '/connectors';
+
+export const getTabPathname = (tab: ConnectorsTabs) =>
+  `${connectorsPathname}/${tab}` as const;
+
+export const connectorTypeToTab = (type: ConnectorType): ConnectorsTabs =>
+  type === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless;
+
+export const getConnectorsPathname = (isSocial: boolean) =>
+  getTabPathname(isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless);
+
+export const buildCreatePathname = (connectorType: ConnectorType) =>
+  `${getTabPathname(connectorTypeToTab(connectorType))}/create/${connectorType}` as const;
+
+export const buildGuidePathname = (connectorType: ConnectorType, factoryId: string) =>
+  `${getTabPathname(connectorTypeToTab(connectorType))}/guide/${factoryId}` as const;
+
+export const buildDetailsPathname = (connectorType: ConnectorType, connectorId: string) =>
+  `${getTabPathname(connectorTypeToTab(connectorType))}/${connectorId}` as const;
+
+export const isConnectorType = (value: string): value is ConnectorType =>
+  Object.values<string>(ConnectorType).includes(value);
+
+export const parseToConnectorType = (value?: string): ConnectorType | undefined =>
+  conditional(value && isConnectorType(value) && value);


### PR DESCRIPTION
## Summary
- extract reusable path utilities for connectors
- update Connectors and ConnectorDetails pages to use the new utils

## Testing
- `pnpm --filter @logto/console test:ci` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a480b0c832fa23061e70877b500