### PR TITLE
Implement add‑on pricing API

### DIFF
--- a/packages/console/src/components/ApplicationCreation/CreateForm/Footer/index.tsx
+++ b/packages/console/src/components/ApplicationCreation/CreateForm/Footer/index.tsx
@@ -8,7 +8,7 @@ import QuotaGuardFooter from '@/components/QuotaGuardFooter';
 import SkuName from '@/components/SkuName';
 import { officialWebsiteContactPageLink } from '@/consts';
 import { addOnPricingExplanationLink } from '@/consts/external-links';
-import { machineToMachineAddOnUnitPrice } from '@/consts/subscriptions';
+import useAddOnPricing from '@/hooks/use-add-on-pricing';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import Button, { LinkButton } from '@/ds-components/Button';
 import TextLink from '@/ds-components/TextLink';
@@ -45,6 +45,7 @@ function Footer({ selectedType, isLoading, onClickCreate, isThirdParty }: Props)
     data: { m2mUpsellNoticeAcknowledged },
     update,
   } = useUserPreferences();
+  const { data: addOnPrices } = useAddOnPricing();
 
   if (selectedType) {
     if (
@@ -70,7 +71,7 @@ function Footer({ selectedType, isLoading, onClickCreate, isThirdParty }: Props)
             }}
           >
             {t('add_on.footer.machine_to_machine_app', {
-              price: machineToMachineAddOnUnitPrice,
+              price: addOnPrices.machineToMachineLimit,
             })}
           </Trans>
         </AddOnNoticeFooter>

--- a/packages/console/src/components/PlanUsage/index.tsx
+++ b/packages/console/src/components/PlanUsage/index.tsx
@@ -19,7 +19,7 @@ import styles from './index.module.scss';
 import {
   type UsageKey,
   usageKeys,
-  usageKeyPriceMap,
+  useUsageKeyPriceMap,
   titleKeyMap,
   tooltipKeyMap,
   enterpriseTooltipKeyMap,
@@ -73,6 +73,7 @@ function PlanUsage({ periodicUsage, usageAddOnSkus }: Props) {
 
   const isPaidTenant = isPaidPlan(planId, isEnterprisePlan);
   const onlyShowPeriodicUsage = planId === ReservedPlanId.Free;
+  const usageKeyPriceMap = useUsageKeyPriceMap();
 
   const usages: PlanUsageCardProps[] = usageKeys
     // Show all usages for Pro plan and only show MAU and token usage for Free plan

--- a/packages/console/src/components/PlanUsage/utils.ts
+++ b/packages/console/src/components/PlanUsage/utils.ts
@@ -1,17 +1,8 @@
 import { type TFuncKey } from 'i18next';
+import { useMemo } from 'react';
 
 import { type NewSubscriptionQuota } from '@/cloud/types/router';
-import {
-  resourceAddOnUnitPrice,
-  machineToMachineAddOnUnitPrice,
-  tenantMembersAddOnUnitPrice,
-  mfaAddOnUnitPrice,
-  enterpriseSsoAddOnUnitPrice,
-  organizationAddOnUnitPrice,
-  tokenAddOnUnitPrice,
-  hooksAddOnUnitPrice,
-  securityFeaturesAddOnUnitPrice,
-} from '@/consts/subscriptions';
+import useAddOnPricing from '@/hooks/use-add-on-pricing';
 
 export type UsageKey = Pick<
   NewSubscriptionQuota,
@@ -40,17 +31,24 @@ export const usageKeys: Array<keyof UsageKey> = [
   'securityFeaturesEnabled',
 ];
 
-export const usageKeyPriceMap: Record<keyof UsageKey, number> = {
-  mauLimit: 0,
-  organizationsLimit: organizationAddOnUnitPrice,
-  mfaEnabled: mfaAddOnUnitPrice,
-  enterpriseSsoLimit: enterpriseSsoAddOnUnitPrice,
-  resourcesLimit: resourceAddOnUnitPrice,
-  machineToMachineLimit: machineToMachineAddOnUnitPrice,
-  tenantMembersLimit: tenantMembersAddOnUnitPrice,
-  tokenLimit: tokenAddOnUnitPrice,
-  hooksLimit: hooksAddOnUnitPrice,
-  securityFeaturesEnabled: securityFeaturesAddOnUnitPrice,
+export const useUsageKeyPriceMap = (): Record<keyof UsageKey, number> => {
+  const { data } = useAddOnPricing();
+
+  return useMemo(
+    () => ({
+      mauLimit: 0,
+      organizationsLimit: data.organizationsLimit,
+      mfaEnabled: data.mfaEnabled,
+      enterpriseSsoLimit: data.enterpriseSsoLimit,
+      resourcesLimit: data.resourcesLimit,
+      machineToMachineLimit: data.machineToMachineLimit,
+      tenantMembersLimit: data.tenantMembersLimit,
+      tokenLimit: data.tokenLimit,
+      hooksLimit: data.hooksLimit,
+      securityFeaturesEnabled: data.securityFeaturesEnabled,
+    }),
+    [data]
+  );
 };
 
 export const titleKeyMap: Record<

--- a/packages/console/src/consts/add-on-sku-ids.ts
+++ b/packages/console/src/consts/add-on-sku-ids.ts
@@ -1,0 +1,15 @@
+export const addOnSkuIdMap = {
+  resourcesLimit: 'api_resource',
+  machineToMachineLimit: 'machine_to_machine',
+  tenantMembersLimit: 'tenant_member',
+  mfaEnabled: 'mfa',
+  enterpriseSsoLimit: 'enterprise_sso',
+  organizationsLimit: 'organization',
+  tokenLimit: 'token_usage',
+  hooksLimit: 'hooks',
+  securityFeaturesEnabled: 'security_features',
+} as const;
+
+export type AddOnUsageKey = keyof typeof addOnSkuIdMap;
+
+export const addOnSkuIds = Object.values(addOnSkuIdMap);

--- a/packages/console/src/consts/subscriptions.ts
+++ b/packages/console/src/consts/subscriptions.ts
@@ -10,20 +10,6 @@ export const freePlanPermissionsLimit = 1;
 export const freePlanAuditLogsRetentionDays = 3;
 export const proPlanAuditLogsRetentionDays = 14;
 
-// TODO: currently we do not provide a good way to retrieve add-on items unit price in console, we hence manually defined the unit price here, will implement the API soon.
-/* === Add-on unit price (in USD) === */
-export const proPlanBasePrice = 16;
-export const resourceAddOnUnitPrice = 4;
-export const machineToMachineAddOnUnitPrice = 8;
-export const tenantMembersAddOnUnitPrice = 8;
-export const mfaAddOnUnitPrice = 48;
-export const enterpriseSsoAddOnUnitPrice = 48;
-export const organizationAddOnUnitPrice = 48;
-export const tokenAddOnUnitPrice = 80;
-export const hooksAddOnUnitPrice = 2;
-export const securityFeaturesAddOnUnitPrice = 48;
-/* === Add-on unit price (in USD) === */
-
 /**
  * In console, only featured plans are shown in the plan selection component.
  * we will this to filter out the public visible featured plans.

--- a/packages/console/src/hooks/use-add-on-pricing.ts
+++ b/packages/console/src/hooks/use-add-on-pricing.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import useSWRImmutable from 'swr/immutable';
+
+import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
+import { type LogtoSkuResponse } from '@/cloud/types/router';
+import { isCloud } from '@/consts/env';
+import { addOnSkuIdMap, type AddOnUsageKey } from '@/consts/add-on-sku-ids';
+import { LogtoSkuType } from '@/types/skus';
+
+/**
+ * Fetch add-on pricing information from the cloud API.
+ *
+ * The API returns add-on SKUs with their unit prices. This hook
+ * converts the response to a record keyed by SKU id for easy lookup.
+ */
+const useAddOnPricing = () => {
+  const cloudApi = useCloudApi();
+
+  const swrResponse = useSWRImmutable<LogtoSkuResponse[], Error>(
+    isCloud && '/api/skus?type=AddOn',
+    async () =>
+      cloudApi.get('/api/skus', {
+        search: { type: LogtoSkuType.AddOn },
+      })
+  );
+
+  const { data } = swrResponse;
+
+  const priceMap = useMemo(() => {
+    const map: Record<AddOnUsageKey, number> = {
+      resourcesLimit: 0,
+      machineToMachineLimit: 0,
+      tenantMembersLimit: 0,
+      mfaEnabled: 0,
+      enterpriseSsoLimit: 0,
+      organizationsLimit: 0,
+      tokenLimit: 0,
+      hooksLimit: 0,
+      securityFeaturesEnabled: 0,
+    };
+
+    data?.forEach((sku) => {
+      const usageKey = Object.entries(addOnSkuIdMap).find(
+        ([, id]) => id === sku.id
+      )?.[0] as AddOnUsageKey | undefined;
+
+      if (usageKey) {
+        map[usageKey] = sku.unitPrice ?? 0;
+      }
+    });
+
+    return map;
+  }, [data]);
+
+  return { ...swrResponse, data: priceMap };
+};
+
+export default useAddOnPricing;

--- a/packages/console/src/pages/ApiResources/components/CreateForm/Footer.tsx
+++ b/packages/console/src/pages/ApiResources/components/CreateForm/Footer.tsx
@@ -7,7 +7,7 @@ import ContactUsPhraseLink from '@/components/ContactUsPhraseLink';
 import QuotaGuardFooter from '@/components/QuotaGuardFooter';
 import SkuName from '@/components/SkuName';
 import { addOnPricingExplanationLink } from '@/consts/external-links';
-import { resourceAddOnUnitPrice } from '@/consts/subscriptions';
+import useAddOnPricing from '@/hooks/use-add-on-pricing';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import Button from '@/ds-components/Button';
 import TextLink from '@/ds-components/TextLink';
@@ -34,6 +34,7 @@ function Footer({ isCreationLoading, onClickCreate }: Props) {
     data: { apiResourceUpsellNoticeAcknowledged },
     update,
   } = useUserPreferences();
+  const { data: addOnPrices } = useAddOnPricing();
 
   if (
     hasReachedLimit &&
@@ -80,7 +81,7 @@ function Footer({ isCreationLoading, onClickCreate }: Props) {
           }}
         >
           {t('upsell.add_on.footer.api_resource', {
-            price: resourceAddOnUnitPrice,
+            price: addOnPrices.resourcesLimit,
           })}
         </Trans>
       </AddOnNoticeFooter>

--- a/packages/console/src/pages/EnterpriseSso/SsoCreationModal/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/SsoCreationModal/index.tsx
@@ -18,7 +18,8 @@ import { getConnectorRadioGroupSize } from '@/components/CreateConnectorForm/uti
 import QuotaGuardFooter from '@/components/QuotaGuardFooter';
 import { isCloud } from '@/consts/env';
 import { addOnPricingExplanationLink } from '@/consts/external-links';
-import { enterpriseSsoAddOnUnitPrice, latestProPlanId } from '@/consts/subscriptions';
+import { latestProPlanId } from '@/consts/subscriptions';
+import useAddOnPricing from '@/hooks/use-add-on-pricing';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import Button from '@/ds-components/Button';
 import DynamicT from '@/ds-components/DynamicT';
@@ -57,6 +58,7 @@ function SsoCreationModal({ isOpen, onClose: rawOnClose }: Props) {
     data: { enterpriseSsoUpsellNoticeAcknowledged },
     update,
   } = useUserPreferences();
+  const { data: addOnPrices } = useAddOnPricing();
   const [selectedProviderName, setSelectedProviderName] = useState<string>();
 
   const isSsoEnabled =
@@ -175,7 +177,7 @@ function SsoCreationModal({ isOpen, onClose: rawOnClose }: Props) {
                   }}
                 >
                   {t('upsell.add_on.footer.enterprise_sso', {
-                    price: enterpriseSsoAddOnUnitPrice,
+                    price: addOnPrices.enterpriseSsoLimit,
                     planName: t(
                       isEnterprisePlan ? 'subscription.enterprise' : 'subscription.pro_plan'
                     ),

--- a/packages/console/src/pages/Mfa/MfaForm/UpsellNotice/index.tsx
+++ b/packages/console/src/pages/Mfa/MfaForm/UpsellNotice/index.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { addOnPricingExplanationLink } from '@/consts/external-links';
-import { mfaAddOnUnitPrice } from '@/consts/subscriptions';
+import useAddOnPricing from '@/hooks/use-add-on-pricing';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import InlineNotification from '@/ds-components/InlineNotification';
 import TextLink from '@/ds-components/TextLink';
@@ -22,6 +22,7 @@ function UpsellNotice({ className }: Props) {
     data: { mfaUpsellNoticeAcknowledged },
     update,
   } = useUserPreferences();
+  const { data: addOnPrices } = useAddOnPricing();
 
   const isPaidTenant = isPaidPlan(planId, isEnterprisePlan);
 
@@ -43,7 +44,7 @@ function UpsellNotice({ className }: Props) {
         }}
       >
         {t('upsell.add_on.mfa_inline_notification', {
-          price: mfaAddOnUnitPrice,
+          price: addOnPrices.mfaEnabled,
           planName: String(t('subscription.pro_plan')),
         })}
       </Trans>

--- a/packages/console/src/pages/Organizations/CreateOrganizationModal/index.tsx
+++ b/packages/console/src/pages/Organizations/CreateOrganizationModal/index.tsx
@@ -10,7 +10,7 @@ import ContactUsPhraseLink from '@/components/ContactUsPhraseLink';
 import QuotaGuardFooter from '@/components/QuotaGuardFooter';
 import { isCloud } from '@/consts/env';
 import { addOnPricingExplanationLink } from '@/consts/external-links';
-import { latestProPlanId, organizationAddOnUnitPrice } from '@/consts/subscriptions';
+import { latestProPlanId } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import Button from '@/ds-components/Button';
 import FormField from '@/ds-components/FormField';
@@ -19,6 +19,7 @@ import TextInput from '@/ds-components/TextInput';
 import TextLink from '@/ds-components/TextLink';
 import useApi from '@/hooks/use-api';
 import useUserPreferences from '@/hooks/use-user-preferences';
+import useAddOnPricing from '@/hooks/use-add-on-pricing';
 import modalStyles from '@/scss/modal.module.scss';
 import { trySubmitSafe } from '@/utils/form';
 import { isPaidPlan, isFeatureEnabled } from '@/utils/subscription';
@@ -41,6 +42,7 @@ function CreateOrganizationModal({ isOpen, onClose }: Props) {
     data: { organizationUpsellNoticeAcknowledged },
     update,
   } = useUserPreferences();
+  const { data: addOnPrices } = useAddOnPricing();
   const isPaidTenant = isPaidPlan(planId, isEnterprisePlan);
   const isOrganizationsDisabled =
     // Check if the organizations feature is disabled except for paid tenants.
@@ -103,7 +105,7 @@ function CreateOrganizationModal({ isOpen, onClose }: Props) {
                   }}
                 >
                   {t('upsell.add_on.footer.organization', {
-                    price: organizationAddOnUnitPrice,
+                    price: addOnPrices.organizationsLimit,
                     planName: t(
                       isEnterprisePlan ? 'subscription.enterprise' : 'subscription.pro_plan'
                     ),

--- a/packages/console/src/pages/Security/PaywallNotification/index.tsx
+++ b/packages/console/src/pages/Security/PaywallNotification/index.tsx
@@ -1,7 +1,7 @@
 import { Trans, useTranslation } from 'react-i18next';
 
 import ContactUsPhraseLink from '@/components/ContactUsPhraseLink';
-import { securityFeaturesAddOnUnitPrice } from '@/consts/subscriptions';
+import useAddOnPricing from '@/hooks/use-add-on-pricing';
 import InlineNotification from '@/ds-components/InlineNotification';
 import usePaywall from '@/hooks/use-paywall';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
@@ -21,6 +21,7 @@ function PaywallNotification({ className }: Props) {
     data: { securityFeaturesUpsellNoticeAcknowledged },
     update,
   } = useUserPreferences();
+  const { data: addOnPrices } = useAddOnPricing();
 
   if (isFreeTenant) {
     return (
@@ -54,7 +55,7 @@ function PaywallNotification({ className }: Props) {
         onClick={async () => update({ securityFeaturesUpsellNoticeAcknowledged: true })}
       >
         {t('upsell.add_on.security_features_inline_notification', {
-          price: securityFeaturesAddOnUnitPrice,
+          price: addOnPrices.securityFeaturesEnabled,
         })}
       </InlineNotification>
     );

--- a/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/AddOnUsageChangesNotification/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/AddOnUsageChangesNotification/index.tsx
@@ -2,7 +2,6 @@ import { useContext } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { addOnPricingExplanationLink } from '@/consts/external-links';
-import { proPlanBasePrice } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import InlineNotification from '@/ds-components/InlineNotification';
 import TextLink from '@/ds-components/TextLink';
@@ -17,6 +16,7 @@ function AddOnUsageChangesNotification({ className }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const {
     currentSubscription: { planId, isEnterprisePlan },
+    currentSku,
   } = useContext(SubscriptionDataContext);
   const {
     data: { addOnChangesInCurrentCycleNoticeAcknowledged },
@@ -43,7 +43,7 @@ function AddOnUsageChangesNotification({ className }: Props) {
         }}
       >
         {t('subscription.usage.pricing.add_on_changes_in_current_cycle_notice', {
-          price: proPlanBasePrice,
+          price: currentSku.unitPrice ?? 0,
         })}
       </Trans>
     </InlineNotification>

--- a/packages/console/src/pages/TenantSettings/TenantMembers/InviteMemberModal/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/InviteMemberModal/index.tsx
@@ -9,7 +9,8 @@ import ReactModal from 'react-modal';
 import { useAuthedCloudApi } from '@/cloud/hooks/use-cloud-api';
 import AddOnNoticeFooter from '@/components/AddOnNoticeFooter';
 import { addOnPricingExplanationLink } from '@/consts/external-links';
-import { latestProPlanId, tenantMembersAddOnUnitPrice } from '@/consts/subscriptions';
+import { latestProPlanId } from '@/consts/subscriptions';
+import useAddOnPricing from '@/hooks/use-add-on-pricing';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import FormField from '@/ds-components/FormField';
@@ -50,6 +51,7 @@ function InviteMemberModal({ isOpen, onClose }: Props) {
     data: { tenantMembersUpsellNoticeAcknowledged },
     update,
   } = useUserPreferences();
+  const { data: addOnPrices } = useAddOnPricing();
   const isPaidTenant = isPaidPlan(planId, isEnterprisePlan);
 
   const formMethods = useForm<InviteMemberForm>({
@@ -151,7 +153,7 @@ function InviteMemberModal({ isOpen, onClose }: Props) {
                     }}
                   >
                     {t('upsell.add_on.footer.tenant_members', {
-                      price: tenantMembersAddOnUnitPrice,
+                      price: addOnPrices.tenantMembersLimit,
                     })}
                   </Trans>
                 </AddOnNoticeFooter>


### PR DESCRIPTION
## Summary
- add useAddOnPricing hook to fetch pricing from Cloud
- map add-on SKU IDs to usage keys
- remove hard-coded add-on price constants
- show dynamic pricing in usage cards and upsell notices

## Testing
- `pnpm -r test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a3e5264832f965e2e02965e00c6