### PR TITLE
Remove RegExp check for confidential connector fields

### DIFF
--- a/packages/connectors/connector-alipay-native/src/constant.ts
+++ b/packages/connectors/connector-alipay-native/src/constant.ts
@@ -48,6 +48,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'Private Key',
       type: ConnectorConfigFormItemType.MultilineText,
       required: true,
+      isConfidential: true,
       placeholder: '<private-key>',
     },
     {

--- a/packages/connectors/connector-alipay-web/src/constant.ts
+++ b/packages/connectors/connector-alipay-web/src/constant.ts
@@ -51,6 +51,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'Private Key',
       type: ConnectorConfigFormItemType.MultilineText,
       required: true,
+      isConfidential: true,
       placeholder: '<private-key>',
     },
     {

--- a/packages/connectors/connector-aliyun-dm/src/constant.ts
+++ b/packages/connectors/connector-aliyun-dm/src/constant.ts
@@ -42,6 +42,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'Access Key Secret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
       placeholder: '<access-key-secret>',
     },
     {

--- a/packages/connectors/connector-aliyun-sms/src/constant.ts
+++ b/packages/connectors/connector-aliyun-sms/src/constant.ts
@@ -58,6 +58,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'Access Key Secret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
       placeholder: '<access-key-secret>',
     },
     {

--- a/packages/connectors/connector-amazon/src/constant.ts
+++ b/packages/connectors/connector-amazon/src/constant.ts
@@ -38,7 +38,8 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       label: 'Client Secret',
       required: true,
-    },
+      isConfidential: true,
+},
     {
       key: 'scope',
       type: ConnectorConfigFormItemType.Text,

--- a/packages/connectors/connector-aws-ses/src/constant.ts
+++ b/packages/connectors/connector-aws-ses/src/constant.ts
@@ -35,7 +35,8 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'Access Key Secret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
-      placeholder: '<access-key-secret>',
+      isConfidential: true,
+placeholder: '<access-key-secret>',
     },
     {
       key: 'region',

--- a/packages/connectors/connector-azuread/src/constant.ts
+++ b/packages/connectors/connector-azuread/src/constant.ts
@@ -35,7 +35,9 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'clientSecret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+
       label: 'Client Secret',
+      isConfidential: true,
       placeholder: '<client-secret>',
     },
     {

--- a/packages/connectors/connector-dingtalk-web/src/constant.ts
+++ b/packages/connectors/connector-dingtalk-web/src/constant.ts
@@ -42,7 +42,9 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'clientSecret',
       label: 'Client Secret',
       required: true,
+
       type: ConnectorConfigFormItemType.Text,
+      isConfidential: true,
       placeholder: '<client-secret>',
     },
     {

--- a/packages/connectors/connector-discord/src/constant.ts
+++ b/packages/connectors/connector-discord/src/constant.ts
@@ -49,7 +49,9 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'clientSecret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+
       label: 'Client Secret',
+      isConfidential: true,
       placeholder: '<client-secret>',
     },
     {

--- a/packages/connectors/connector-facebook/src/constant.ts
+++ b/packages/connectors/connector-facebook/src/constant.ts
@@ -46,7 +46,9 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'clientSecret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+
       label: 'Client Secret',
+      isConfidential: true,
       placeholder: '<client-secret>',
     },
     {

--- a/packages/connectors/connector-feishu-web/src/constant.ts
+++ b/packages/connectors/connector-feishu-web/src/constant.ts
@@ -35,6 +35,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'App Secret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
       placeholder: '<app-secret>',
     },
   ],

--- a/packages/connectors/connector-github/src/constant.ts
+++ b/packages/connectors/connector-github/src/constant.ts
@@ -44,7 +44,8 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       label: 'Client Secret',
       required: true,
-      placeholder: '<client-secret>',
+      isConfidential: true,
+placeholder: '<client-secret>',
     },
     {
       key: 'scope',

--- a/packages/connectors/connector-google/src/constant.ts
+++ b/packages/connectors/connector-google/src/constant.ts
@@ -46,6 +46,7 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       label: 'Client Secret',
       required: true,
+      isConfidential: true,
       placeholder: '<client-secret>',
     },
     {

--- a/packages/connectors/connector-kook/src/constant.ts
+++ b/packages/connectors/connector-kook/src/constant.ts
@@ -53,6 +53,7 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'clientSecret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
       label: 'Client Secret',
       placeholder: '<client-secret>',
     },

--- a/packages/connectors/connector-line/src/constant.ts
+++ b/packages/connectors/connector-line/src/constant.ts
@@ -39,6 +39,7 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       label: 'Client Secret (Channel Secret)',
       required: true,
+      isConfidential: true,
     },
     {
       key: 'scope',

--- a/packages/connectors/connector-linkedin/src/constant.ts
+++ b/packages/connectors/connector-linkedin/src/constant.ts
@@ -39,6 +39,7 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       label: 'Client Secret',
       required: true,
+      isConfidential: true,
     },
     {
       key: 'scope',

--- a/packages/connectors/connector-logto-email/src/constant.ts
+++ b/packages/connectors/connector-logto-email/src/constant.ts
@@ -76,6 +76,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'App Secret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
     },
     {
       key: 'senderName',

--- a/packages/connectors/connector-logto-sms/src/constant.ts
+++ b/packages/connectors/connector-logto-sms/src/constant.ts
@@ -44,6 +44,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'App Secret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
     },
   ],
 };

--- a/packages/connectors/connector-mailgun/src/constant.ts
+++ b/packages/connectors/connector-mailgun/src/constant.ts
@@ -36,6 +36,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'API Key',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
       placeholder: '<your-mailgun-api-key>',
     },
     {

--- a/packages/connectors/connector-naver/src/constant.ts
+++ b/packages/connectors/connector-naver/src/constant.ts
@@ -36,6 +36,7 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'clientSecret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
       label: 'Client Secret',
       placeholder: '<client-secret>',
     },

--- a/packages/connectors/connector-oauth2/src/oauth2/form-items.ts
+++ b/packages/connectors/connector-oauth2/src/oauth2/form-items.ts
@@ -31,6 +31,7 @@ export const clientSecretFormItem: ConnectorConfigFormItem = Object.freeze({
   label: 'Client Secret',
   type: ConnectorConfigFormItemType.Text,
   required: true,
+  isConfidential: true,
   placeholder: '<client-secret>',
 });
 

--- a/packages/connectors/connector-qq/src/constant.ts
+++ b/packages/connectors/connector-qq/src/constant.ts
@@ -48,6 +48,7 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       label: 'Client Secret',
       required: true,
+      isConfidential: true,
       placeholder: '<client-secret>',
     },
     {

--- a/packages/connectors/connector-saml/src/constant.ts
+++ b/packages/connectors/connector-saml/src/constant.ts
@@ -81,6 +81,7 @@ export const formItems: ConnectorConfigFormItem[] = [
     label: 'Signature Private Key',
     key: 'privateKey',
     required: true,
+
     showConditions: [{ targetKey: 'signAuthnRequest', expectValue: true }],
     placeholder:
       '-----BEGIN RSA PRIVATE KEY-----\n[private-key-content]\n-----END RSA PRIVATE KEY-----',
@@ -103,6 +104,7 @@ export const formItems: ConnectorConfigFormItem[] = [
     label: 'Decryption Private Key',
     key: 'encPrivateKey',
     required: true,
+      isConfidential: true,
     showConditions: [{ targetKey: 'encryptAssertion', expectValue: true }],
     placeholder:
       '-----BEGIN RSA PRIVATE KEY-----\n[private-key-content]\n-----END RSA PRIVATE KEY-----',

--- a/packages/connectors/connector-sendgrid-email/src/constant.ts
+++ b/packages/connectors/connector-sendgrid-email/src/constant.ts
@@ -26,6 +26,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'API Key',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
       placeholder: '<your-sendgrid-api-key>',
     },
     {

--- a/packages/connectors/connector-slack/src/constant.ts
+++ b/packages/connectors/connector-slack/src/constant.ts
@@ -37,6 +37,7 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       label: 'Client Secret',
       required: true,
+      isConfidential: true,
     },
     {
       key: 'scope',

--- a/packages/connectors/connector-smsaero/src/constant.ts
+++ b/packages/connectors/connector-smsaero/src/constant.ts
@@ -29,6 +29,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'API Key',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
       placeholder: '<api-key>',
     },
     {

--- a/packages/connectors/connector-tencent-sms/src/constant.ts
+++ b/packages/connectors/connector-tencent-sms/src/constant.ts
@@ -33,6 +33,7 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'Access Key Secret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
       placeholder: '<access-key-secret>',
     },
     {

--- a/packages/connectors/connector-vonage-sms/src/constant.ts
+++ b/packages/connectors/connector-vonage-sms/src/constant.ts
@@ -20,12 +20,14 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'API Key',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+
     },
     {
       key: 'apiSecret',
       label: 'API Secret',
       type: ConnectorConfigFormItemType.Text,
       required: true,
+      isConfidential: true,
     },
     {
       key: 'brandName',

--- a/packages/connectors/connector-wechat-native/src/constant.ts
+++ b/packages/connectors/connector-wechat-native/src/constant.ts
@@ -42,6 +42,7 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'appSecret',
       label: 'App Secret',
       required: true,
+      isConfidential: true,
       type: ConnectorConfigFormItemType.Text,
       placeholder: '<app-secret>',
     },

--- a/packages/connectors/connector-wechat-web/src/constant.ts
+++ b/packages/connectors/connector-wechat-web/src/constant.ts
@@ -42,6 +42,7 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'appSecret',
       label: 'App Secret',
       required: true,
+      isConfidential: true,
       type: ConnectorConfigFormItemType.Text,
       placeholder: '<app-secret>',
     },

--- a/packages/connectors/connector-wecom/src/constant.ts
+++ b/packages/connectors/connector-wecom/src/constant.ts
@@ -41,6 +41,7 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'appSecret',
       label: 'App Secret',
       required: true,
+      isConfidential: true,
       type: ConnectorConfigFormItemType.Text,
       placeholder: '<app-secret>',
     },

--- a/packages/connectors/connector-x/src/constant.ts
+++ b/packages/connectors/connector-x/src/constant.ts
@@ -38,6 +38,7 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       label: 'Client Secret',
       required: true,
+      isConfidential: true,
     },
     {
       key: 'scope',

--- a/packages/connectors/connector-xiaomi/src/constant.ts
+++ b/packages/connectors/connector-xiaomi/src/constant.ts
@@ -36,6 +36,7 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       label: 'Client Secret',
       required: true,
+      isConfidential: true,
       placeholder: '<client-secret>',
     },
     {

--- a/packages/console/src/components/ConnectorForm/ConfigForm/ConfigFormFields/index.tsx
+++ b/packages/console/src/components/ConnectorForm/ConfigForm/ConfigFormFields/index.tsx
@@ -69,8 +69,7 @@ function ConfigFormFields({ formItems }: Props) {
       return (
         <TextInput
           {...buildCommonProperties()}
-          // TODO: update connectors form config and remove RegExp check
-          isConfidential={item.isConfidential ?? /(Key|Secret)$/.test(item.key)}
+          isConfidential={item.isConfidential}
         />
       );
     }


### PR DESCRIPTION
## Summary
- mark confidential fields in connector templates
- rely on typed config for confidential flags

## Testing
- `pnpm -r test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a3876e0832f90eff980520f241a