### PR TITLE
Remove deprecated captchaEnabled usage

### DIFF
--- a/packages/console/src/consts/plan-quotas.ts
+++ b/packages/console/src/consts/plan-quotas.ts
@@ -37,5 +37,4 @@ export const skuQuotaItemOrder: Array<keyof LogtoSkuQuota> = [
   'ticketSupportResponseTime',
 ];
 
-// TODO: @sijie remove this after the captcha quota is removed from the plan
-export const comingSoonSkuQuotaKeys: Array<keyof LogtoSkuQuota> = ['captchaEnabled'];
+export const comingSoonSkuQuotaKeys: Array<keyof LogtoSkuQuota> = [];

--- a/packages/console/src/consts/quota-item-phrases.ts
+++ b/packages/console/src/consts/quota-item-phrases.ts
@@ -30,7 +30,6 @@ export const skuQuotaItemPhrasesMap: Record<
   bringYourUiEnabled: 'bring_your_ui_enabled.name',
   idpInitiatedSsoEnabled: 'idp_initiated_sso_enabled.name',
   samlApplicationsLimit: 'saml_applications_limit.name',
-  captchaEnabled: 'captcha_enabled.name',
   securityFeaturesEnabled: 'security_features_enabled.name',
 };
 
@@ -61,7 +60,6 @@ export const skuQuotaItemUnlimitedPhrasesMap: Record<
   bringYourUiEnabled: 'bring_your_ui_enabled.unlimited',
   idpInitiatedSsoEnabled: 'idp_initiated_sso_enabled.unlimited',
   samlApplicationsLimit: 'saml_applications_limit.unlimited',
-  captchaEnabled: 'captcha_enabled.unlimited',
   securityFeaturesEnabled: 'security_features_enabled.unlimited',
 };
 
@@ -92,7 +90,6 @@ export const skuQuotaItemLimitedPhrasesMap: Record<
   bringYourUiEnabled: 'bring_your_ui_enabled.limited',
   idpInitiatedSsoEnabled: 'idp_initiated_sso_enabled.limited',
   samlApplicationsLimit: 'saml_applications_limit.limited',
-  captchaEnabled: 'captcha_enabled.limited',
   securityFeaturesEnabled: 'security_features_enabled.limited',
 };
 
@@ -123,7 +120,6 @@ export const skuQuotaItemNotEligiblePhrasesMap: Record<
   bringYourUiEnabled: 'bring_your_ui_enabled.not_eligible',
   idpInitiatedSsoEnabled: 'idp_initiated_sso_enabled.not_eligible',
   samlApplicationsLimit: 'saml_applications_limit.not_eligible',
-  captchaEnabled: 'captcha_enabled.not_eligible',
   securityFeaturesEnabled: 'security_features_enabled.not_eligible',
 };
 /* === for new pricing model === */

--- a/packages/console/src/consts/tenants.ts
+++ b/packages/console/src/consts/tenants.ts
@@ -84,7 +84,6 @@ export const defaultLogtoSku: LogtoSkuResponse = {
     subjectTokenEnabled: true,
     bringYourUiEnabled: true,
     idpInitiatedSsoEnabled: false,
-    captchaEnabled: true,
     securityFeaturesEnabled: true,
   },
 };
@@ -113,7 +112,6 @@ export const defaultSubscriptionQuota: NewSubscriptionQuota = {
   bringYourUiEnabled: false,
   idpInitiatedSsoEnabled: false,
   samlApplicationsLimit: 0,
-  captchaEnabled: false,
   securityFeaturesEnabled: false,
 };
 
@@ -137,7 +135,6 @@ export const defaultSubscriptionUsage: NewSubscriptionCountBasedUsage = {
   bringYourUiEnabled: false,
   idpInitiatedSsoEnabled: false,
   samlApplicationsLimit: 0,
-  captchaEnabled: false,
   securityFeaturesEnabled: false,
 };
 

--- a/packages/core/src/__mocks__/cloud-connection.ts
+++ b/packages/core/src/__mocks__/cloud-connection.ts
@@ -38,7 +38,6 @@ export const mockQuota = {
   idpInitiatedSsoEnabled: false,
   samlApplicationsLimit: 0,
   securityFeaturesEnabled: false,
-  captchaEnabled: false,
 };
 
 export const mockSubscriptionData: Subscription = {

--- a/packages/core/src/utils/subscription/types.ts
+++ b/packages/core/src/utils/subscription/types.ts
@@ -34,16 +34,12 @@ export type SubscriptionQuota = Omit<
   | 'auditLogsRetentionDays'
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
   | 'organizationsEnabled'
-  // Since we will deprecate the `captchaEnabled` key soon (use `securityFeaturesEnabled` instead), we exclude it from the usage keys for now to avoid confusion.
-  | 'captchaEnabled'
 >;
 
 export type SubscriptionUsage = Omit<
   CompleteSubscriptionUsage['usage'],
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
   | 'organizationsEnabled'
-  // Since we will deprecate the `captchaEnabled` key soon (use `securityFeaturesEnabled` instead), we exclude it from the usage keys for now to avoid confusion.
-  | 'captchaEnabled'
 >;
 
 export type ReportSubscriptionUpdatesUsageKey = Exclude<
@@ -106,11 +102,6 @@ const logtoSkuQuotaGuard = z.object({
   organizationsLimit: z.number().nullable(),
   idpInitiatedSsoEnabled: z.boolean(),
   samlApplicationsLimit: z.number().nullable(),
-  /**
-   * @deprecated
-   * TODO: @sijie remove this
-   */
-  captchaEnabled: z.boolean(),
   securityFeaturesEnabled: z.boolean(),
 }) satisfies ToZodObject<SubscriptionQuota>;
 


### PR DESCRIPTION
## Summary
- drop `captchaEnabled` from subscription schema and mocks
- clean up console tenant defaults and quota phrase maps
- clear coming soon quota list

## Testing
- `pnpm -r --parallel --workspace-concurrency=0 test:ci` *(fails: Local package.json exists, but node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a2c6284832fa038aeda61d31399