### PR TITLE
Refactor SAML app modules

### DIFF
--- a/packages/core/src/saml-application/SamlApplication/attribute-utils.ts
+++ b/packages/core/src/saml-application/SamlApplication/attribute-utils.ts
@@ -1,0 +1,148 @@
+import { userClaims, type UserClaim, UserScope, ReservedScope } from '@logto/core-kit';
+import { NameIdFormat, type SamlAttributeMapping } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+import saml from 'samlify';
+
+import {
+  samlLogInResponseTemplate,
+  samlAttributeNameFormatBasic,
+  samlValueXmlnsXsi,
+  fallbackAttributes,
+} from './consts.js';
+import { buildSamlAssertionNameId, generateSamlAttributeTag } from './utils.js';
+import assertThat from '#src/utils/assert-that.js';
+import type { IdTokenProfileStandardClaims } from '#src/sso/types/oidc.js';
+
+export const buildLoginResponseTemplate = (
+  attributeMapping: SamlAttributeMapping
+) => ({
+  context: samlLogInResponseTemplate,
+  attributes: (Object.entries(attributeMapping).length > 0
+    ? Object.values(attributeMapping)
+    : fallbackAttributes
+  ).map((value) => ({
+    name: value,
+    valueTag: value,
+    nameFormat: samlAttributeNameFormatBasic,
+    valueXsiType: samlValueXmlnsXsi.string,
+  })),
+});
+
+export const buildSamlAttributesTagValues = (
+  userInfo: IdTokenProfileStandardClaims,
+  attributeMapping: SamlAttributeMapping
+): Record<string, string | null> => {
+  return Object.entries(attributeMapping).length > 0
+    ? Object.fromEntries(
+        Object.entries(attributeMapping)
+          .map(([key, value]) => [
+            value,
+            userInfo[key as keyof IdTokenProfileStandardClaims] ?? null,
+          ])
+          .map(([key, value]) => [
+            generateSamlAttributeTag(key),
+            typeof value === 'object' ? JSON.stringify(value) : String(value),
+          ])
+      )
+    : Object.fromEntries(
+        fallbackAttributes.map((attribute) => [
+          generateSamlAttributeTag(attribute),
+          (typeof userInfo[attribute] === 'boolean'
+            ? String(userInfo[attribute])
+            : userInfo[attribute]) ?? null,
+        ])
+      );
+};
+
+export const createSamlTemplateCallback = (
+  sp: saml.ServiceProviderInstance,
+  idp: saml.IdentityProviderInstance,
+  attributeMapping: SamlAttributeMapping,
+  {
+    userInfo,
+    samlRequestId,
+    sessionId,
+    sessionExpiresAt,
+  }: {
+    userInfo: IdTokenProfileStandardClaims;
+    samlRequestId: string | null;
+    sessionId?: string;
+    sessionExpiresAt?: string;
+  }
+) =>
+  (template: string) => {
+    const assertionConsumerServiceUrl = sp.entityMeta.getAssertionConsumerService(
+      saml.Constants.wording.binding.post
+    );
+
+    const { nameIDFormat } = idp.entitySetting;
+    assertThat(nameIDFormat, 'application.saml.name_id_format_required');
+    const { NameIDFormat, NameID } = buildSamlAssertionNameId(userInfo, nameIDFormat);
+
+    const id = `ID_${generateStandardId()}`;
+    const now = new Date();
+    const expireAt = new Date(now.getTime() + 10 * 60 * 1000);
+
+    const tagValues = {
+      ID: id,
+      AssertionID: `ID_${generateStandardId()}`,
+      Destination: assertionConsumerServiceUrl,
+      Audience: sp.entityMeta.getEntityID(),
+      EntityID: sp.entityMeta.getEntityID(),
+      SubjectRecipient: assertionConsumerServiceUrl,
+      Issuer: idp.entityMeta.getEntityID(),
+      IssueInstant: now.toISOString(),
+      AssertionConsumerServiceURL: assertionConsumerServiceUrl,
+      StatusCode: saml.Constants.StatusCode.Success,
+      ConditionsNotBefore: now.toISOString(),
+      ConditionsNotOnOrAfter: expireAt.toISOString(),
+      SubjectConfirmationDataNotOnOrAfter: expireAt.toISOString(),
+      NameIDFormat,
+      NameID,
+      InResponseTo: samlRequestId ?? 'null',
+      ...buildSamlAttributesTagValues(userInfo, attributeMapping),
+      AuthnContextClassRef:
+        saml.Constants.namespace.authnContextClassRef.passwordProtectedTransport,
+      SessionNotOnOrAfter: sessionExpiresAt ?? '',
+      SessionIndex: sessionId ?? '',
+    };
+
+    const context = saml.SamlLib.replaceTagsByValue(template, tagValues);
+
+    return {
+      id,
+      context,
+    };
+  };
+
+export const getScopesFromAttributeMapping = (
+  nameIdFormat: NameIdFormat,
+  attributeMapping: SamlAttributeMapping
+): Array<UserScope | ReservedScope> => {
+  const requiredScopes = new Set<UserScope | ReservedScope>();
+  requiredScopes.add(ReservedScope.OpenId);
+  requiredScopes.add(UserScope.Profile);
+
+  if (nameIdFormat === NameIdFormat.EmailAddress) {
+    requiredScopes.add(UserScope.Email);
+  }
+
+  if (Object.keys(attributeMapping).length === 0) {
+    return Array.from(requiredScopes);
+  }
+
+  for (const claim of Object.keys(attributeMapping) as Array<keyof SamlAttributeMapping>) {
+    if (claim === 'sub') {
+      continue;
+    }
+
+    for (const [scope, claims] of Object.entries(userClaims) as Array<[UserScope, UserClaim[]]>) {
+      if (claims.includes(claim)) {
+        requiredScopes.add(scope);
+        break;
+      }
+    }
+  }
+
+  return Array.from(requiredScopes);
+};

--- a/packages/core/src/saml-application/SamlApplication/config.ts
+++ b/packages/core/src/saml-application/SamlApplication/config.ts
@@ -1,0 +1,67 @@
+import { NameIdFormat, type SamlAcsUrl } from '@logto/schemas';
+import { type SamlApplicationDetails } from '#src/queries/saml-application/index.js';
+import assertThat from '#src/utils/assert-that.js';
+
+class SamlApplicationConfig {
+  constructor(
+    private readonly _details: SamlApplicationDetails,
+    private readonly _endpoint: URL
+  ) {}
+
+  private normalizeUrlHost(url: string): string {
+    try {
+      const parsedUrl = new URL(url);
+      if (parsedUrl.host !== this._endpoint.host) {
+        // eslint-disable-next-line @silverhand/fp/no-mutation
+        parsedUrl.host = this._endpoint.host;
+        return parsedUrl.toString();
+      }
+      return url;
+    } catch {
+      return url;
+    }
+  }
+
+  public get secret() {
+    return this._details.secret;
+  }
+
+  public get spEntityId() {
+    assertThat(this._details.entityId, 'application.saml.entity_id_required');
+    return this._details.entityId;
+  }
+
+  public get acsUrl() {
+    assertThat(this._details.acsUrl, 'application.saml.acs_url_required');
+    return this._details.acsUrl as SamlAcsUrl;
+  }
+
+  public get redirectUri() {
+    assertThat(this._details.oidcClientMetadata.redirectUris[0], 'oidc.invalid_redirect_uri');
+    return this.normalizeUrlHost(this._details.oidcClientMetadata.redirectUris[0]);
+  }
+
+  public get privateKey() {
+    assertThat(this._details.privateKey, 'application.saml.private_key_required');
+    return this._details.privateKey;
+  }
+
+  public get certificate() {
+    assertThat(this._details.certificate, 'application.saml.certificate_required');
+    return this._details.certificate;
+  }
+
+  public get nameIdFormat() {
+    return this._details.nameIdFormat as NameIdFormat;
+  }
+
+  public get encryption() {
+    return this._details.encryption;
+  }
+
+  public get attributeMapping() {
+    return this._details.attributeMapping;
+  }
+}
+
+export default SamlApplicationConfig;


### PR DESCRIPTION
## Summary
- modularize SAML application helpers
- correct response binding
- remove remaining TODOs

## Testing
- `pnpm -r lint` *(fails: ESLint couldn't find configuration)*
- `pnpm -r test:ci` *(fails: vitest not found)*
- `pnpm -r build` *(fails: tsconfig path errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a28c190832f83540891e4070c71