### PR TITLE
Add mock for disposable domain validation

### DIFF
--- a/packages/core/src/__mocks__/disposable-email-domain.ts
+++ b/packages/core/src/__mocks__/disposable-email-domain.ts
@@ -1,0 +1,2 @@
+export const mockDisposableEmailDomains = ['disposable.test'];
+

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -66,8 +66,23 @@ const disposableEmailDomainValidationResponseGuard = z.object({
 });
 
 const validateDisposableEmailDomain = async (email: string) => {
-  // TODO: Skip the validation for integration test for now
-  if (EnvSet.values.isIntegrationTest || EnvSet.values.isUnitTest) {
+  if (EnvSet.values.isUnitTest) {
+    return;
+  }
+
+  if (EnvSet.values.isIntegrationTest) {
+    const { mockDisposableEmailDomains } = await import(
+      '#src/__mocks__/disposable-email-domain.js'
+    );
+    const domain = email.split('@')[1];
+    assertThat(
+      !mockDisposableEmailDomains.includes(domain),
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
     return;
   }
 

--- a/packages/toolkit/core-kit/src/utils/integration-test.ts
+++ b/packages/toolkit/core-kit/src/utils/integration-test.ts
@@ -8,3 +8,11 @@ export const getPwnPasswordsForTest = () => {
   }
   return Object.freeze(['123456aA', 'test_password']);
 };
+
+export const getDisposableEmailDomainsForTest = () => {
+  if (!isIntegrationTest()) {
+    throw new Error('This function should only be called in integration tests');
+  }
+
+  return Object.freeze(['disposable.test']);
+};


### PR DESCRIPTION
## Summary
- allow integration tests to validate disposable domains using a mock list
- expose `getDisposableEmailDomainsForTest` helper

## Testing
- `pnpm -r --parallel --workspace-concurrency=0 test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a24e394832f8f8bc7fe3941a81b