### PR TITLE
Introduce shared error base and update connector library

### DIFF
--- a/packages/core/src/errors/BaseError/index.ts
+++ b/packages/core/src/errors/BaseError/index.ts
@@ -1,0 +1,6 @@
+export default class BaseError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}

--- a/packages/core/src/errors/RequestError/index.ts
+++ b/packages/core/src/errors/RequestError/index.ts
@@ -5,6 +5,8 @@ import { conditional, pick } from '@silverhand/essentials';
 import i18next, { type i18n } from 'i18next';
 import { ZodError } from 'zod';
 
+import BaseError from '#src/errors/BaseError/index.js';
+
 export const formatZodError = ({ issues }: ZodError): string[] =>
   issues.map((issue) => {
     const base = `Error in key path "${issue.path.map(String).join('.')}": (${issue.code}) `;
@@ -16,7 +18,7 @@ export const formatZodError = ({ issues }: ZodError): string[] =>
     return base + issue.message;
   });
 
-export default class RequestError extends Error {
+export default class RequestError extends BaseError {
   /**
    * Error message generated using i18n with default language (en).
    *

--- a/packages/core/src/errors/ServerError/index.ts
+++ b/packages/core/src/errors/ServerError/index.ts
@@ -2,7 +2,9 @@
 
 import type { ZodError } from 'zod';
 
-export default class ServerError extends Error {
+import BaseError from '#src/errors/BaseError/index.js';
+
+export default class ServerError extends BaseError {
   constructor(public readonly message: string) {
     super(message);
     this.name = 'ServerError';

--- a/packages/core/src/libraries/connector.ts
+++ b/packages/core/src/libraries/connector.ts
@@ -10,6 +10,7 @@ import { validateConfig, ServiceConnector, ConnectorType } from '@logto/connecto
 import { type Nullable, conditional, pick, trySafe } from '@silverhand/essentials';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import ServerError from '#src/errors/ServerError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 import { loadConnectorFactories } from '#src/utils/connectors/index.js';
@@ -156,12 +157,7 @@ export const createConnectorLibrary = (
     );
     assertThat(
       connector,
-      // TODO: @gao refactor RequestError and ServerError to share the same base class
-      new RequestError({
-        code: 'connector.not_found',
-        type,
-        status: 501,
-      })
+      new ServerError(`Connector for type ${type} is not implemented.`)
     );
     return connector;
   };


### PR DESCRIPTION
## Summary
- add `BaseError` to share error properties
- extend `RequestError` and `ServerError` from `BaseError`
- throw `ServerError` for missing message connectors

## Testing
- `pnpm -r test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a1e13f0832fb9fd7b1f0ad87636