### PR TITLE
Refactor MFA storage and conditional JIT provisioning

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -280,7 +280,21 @@ export default class ExperienceInteraction {
     await this.guardCaptcha();
     await this.profile.assertUserMandatoryProfileFulfilled();
 
-    const user = await this.provisionLibrary.createUser(this.profile.data);
+    const emailVerified = this.verificationRecords
+      .array()
+      .some(
+        (record) =>
+          (record.type === VerificationType.EmailVerificationCode ||
+            record.type === VerificationType.OneTimeToken ||
+            record.type === VerificationType.EnterpriseSso ||
+            record.type === VerificationType.Social) &&
+          record.isVerified
+      );
+
+    const user = await this.provisionLibrary.createUser(
+      this.profile.data,
+      emailVerified
+    );
     log?.append({ user });
 
     this.userId = user.id;

--- a/packages/core/src/routes/experience/classes/libraries/provision-library.ts
+++ b/packages/core/src/routes/experience/classes/libraries/provision-library.ts
@@ -54,7 +54,7 @@ export class ProvisionLibrary {
    * - Provision all JIT organizations for the user if necessary.
    * - Assign the first user to the admin role and the default tenant organization membership. [OSS only]
    */
-  async createUser(profile: InteractionProfile) {
+  async createUser(profile: InteractionProfile, emailVerified = true) {
     const {
       libraries: {
         users: { generateUserId, insertUser },
@@ -84,7 +84,9 @@ export class ProvisionLibrary {
       await this.provisionForFirstAdminUser(user);
     }
 
-    await this.provisionNewUserJitOrganizations(user.id, profile);
+    if (emailVerified) {
+      await this.provisionNewUserJitOrganizations(user.id, profile);
+    }
 
     this.ctx.appendDataHookContext('User.Created', { user });
 

--- a/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
@@ -118,7 +118,7 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
    */
   async verifyUserExistingTotp(code: string) {
     const {
-      users: { findUserById, updateUserById },
+      users: { findUserById, patchUserMfaVerificationById },
     } = this.queries;
 
     const { mfaVerifications } = await findUserById(this.userId);
@@ -134,17 +134,8 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
     this.verified = true;
 
     // Update last used time
-    await updateUserById(this.userId, {
-      mfaVerifications: mfaVerifications.map((mfa) => {
-        if (mfa.id !== totpVerification.id) {
-          return mfa;
-        }
-
-        return {
-          ...mfa,
-          lastUsedAt: new Date().toISOString(),
-        };
-      }),
+    await patchUserMfaVerificationById(this.userId, totpVerification.id, {
+      lastUsedAt: new Date().toISOString(),
     });
   }
 

--- a/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
@@ -214,19 +214,10 @@ export class WebAuthnVerification implements MfaVerificationRecord<VerificationT
     this.verified = true;
 
     // Update the counter and last used time
-    const { updateUserById } = this.queries.users;
-    await updateUserById(this.userId, {
-      mfaVerifications: mfaVerifications.map((mfa) => {
-        if (mfa.type !== MfaFactor.WebAuthn || mfa.id !== result.id) {
-          return mfa;
-        }
-
-        return {
-          ...mfa,
-          lastUsedAt: new Date().toISOString(),
-          ...conditional(newCounter !== undefined && { counter: newCounter }),
-        };
-      }),
+    const { patchUserMfaVerificationById } = this.queries.users;
+    await patchUserMfaVerificationById(this.userId, result.id, {
+      lastUsedAt: new Date().toISOString(),
+      ...conditional(newCounter !== undefined && { counter: newCounter }),
     });
   }
 


### PR DESCRIPTION
## Summary
- refactor user queries to update `mfa_verifications` via jsonb array operations
- update MFA routes and verification classes to use the new query helpers
- only provision JIT organizations when email is verified

## Testing
- `pnpm run ci:lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm run ci:test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a1c1ee8832fb2a3093655ab4fec