### PR TITLE
Remove dev flag for IdP initiated SSO

### DIFF
--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -304,8 +304,5 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
     }
   );
 
-  // TODO: @simeng Remove this when IdP initiated SAML SSO is ready for production
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    ssoConnectorIdpInitiatedAuthConfigRoutes(...args);
-  }
+  ssoConnectorIdpInitiatedAuthConfigRoutes(...args);
 }


### PR DESCRIPTION
## Summary
- always register IdP initiated SAML SSO config routes

## Testing
- `pnpm ci:lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a02b198832fa6a9609874d78c57