### PR TITLE
Fix API routing and middleware naming

### DIFF
--- a/packages/core/src/middleware/koa-api-hooks.test.ts
+++ b/packages/core/src/middleware/koa-api-hooks.test.ts
@@ -5,7 +5,7 @@ import { type ParameterizedContext } from 'koa';
 import type Libraries from '#src/tenants/Libraries.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
-import { koaManagementApiHooks, type WithHookContext } from './koa-management-api-hooks.js';
+import { koaApiHooks, type WithHookContext } from './koa-api-hooks.js';
 
 const { jest } = import.meta;
 
@@ -13,7 +13,7 @@ const notToBeCalled = () => {
   throw new Error('Should not be called');
 };
 
-describe('koaManagementApiHooks', () => {
+describe('koaApiHooks', () => {
   const next = jest.fn();
   const triggerDataHooks = jest.fn();
   // @ts-expect-error mock
@@ -27,7 +27,7 @@ describe('koaManagementApiHooks', () => {
       header: {},
       appendDataHookContext: notToBeCalled,
     };
-    await koaManagementApiHooks(mockHooksLibrary)(ctx, next);
+    await koaApiHooks(mockHooksLibrary)(ctx, next);
     expect(triggerDataHooks).not.toBeCalled();
   });
 
@@ -41,7 +41,7 @@ describe('koaManagementApiHooks', () => {
       ctx.appendDataHookContext('Role.Created', { data: { id: '123' } });
     });
 
-    await koaManagementApiHooks(mockHooksLibrary)(ctx, next);
+    await koaApiHooks(mockHooksLibrary)(ctx, next);
     expect(triggerDataHooks).toBeCalledTimes(1);
     expect(triggerDataHooks).toBeCalledWith(
       expect.any(ConsoleLog),
@@ -82,7 +82,7 @@ describe('koaManagementApiHooks', () => {
         status: 200,
       };
 
-      await koaManagementApiHooks(mockHooksLibrary)(ctx, next);
+      await koaApiHooks(mockHooksLibrary)(ctx, next);
 
       expect(triggerDataHooks).toBeCalledWith(
         expect.any(ConsoleLog),

--- a/packages/core/src/middleware/koa-api-hooks.ts
+++ b/packages/core/src/middleware/koa-api-hooks.ts
@@ -17,7 +17,7 @@ export type WithHookContext<ContextT extends IRouterParamContext = IRouterParamC
  * @param hooks The hooks library.
  * @returns The middleware function.
  */
-export const koaManagementApiHooks = <StateT, ContextT extends IRouterParamContext, ResponseT>(
+export const koaApiHooks = <StateT, ContextT extends IRouterParamContext, ResponseT>(
   hooks: Libraries['hooks']
 ): MiddlewareType<StateT, WithHookContext<ContextT>, ResponseT> => {
   return async (ctx, next) => {

--- a/packages/core/src/routes/admin-user/basics.test.ts
+++ b/packages/core/src/routes/admin-user/basics.test.ts
@@ -6,7 +6,7 @@ import { removeUndefinedKeys } from '@silverhand/essentials';
 import { mockUser, mockUserResponse } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type InsertUserResult } from '#src/libraries/user.js';
-import { koaManagementApiHooks } from '#src/middleware/koa-management-api-hooks.js';
+import { koaApiHooks } from '#src/middleware/koa-api-hooks.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
@@ -100,7 +100,7 @@ describe('adminUserRoutes', () => {
     users: usersLibraries,
   });
   const userRequest = createRequester({
-    middlewares: [koaManagementApiHooks(tenantContext.libraries.hooks)],
+    middlewares: [koaApiHooks(tenantContext.libraries.hooks)],
     authedRoutes: adminUserRoutes,
     tenantContext,
   });

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -23,7 +23,15 @@ import { parseSearchParamsForSearch } from '#src/utils/search.js';
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
 import applicationCustomDataRoutes from './application-custom-data.js';
-import { generateInternalSecret } from './application-secret.js';
+import applicationOrganizationRoutes from './application-organization.js';
+import applicationProtectedAppMetadataRoutes from './application-protected-app-metadata.js';
+import applicationRoleRoutes from './application-role.js';
+import applicationSecretRoutes, {
+  generateInternalSecret,
+} from './application-secret.js';
+import applicationSignInExperienceRoutes from './application-sign-in-experience.js';
+import applicationUserConsentOrganizationRoutes from './application-user-consent-organization.js';
+import applicationUserConsentScopeRoutes from './application-user-consent-scope.js';
 import { applicationCreateGuard, applicationPatchGuard } from './types.js';
 
 const includesInternalAdminRole = (roles: Readonly<Array<{ role: Role }>>) =>
@@ -388,5 +396,12 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
   );
 
   applicationCustomDataRoutes(router, tenant);
+  applicationRoleRoutes(router, tenant);
+  applicationProtectedAppMetadataRoutes(router, tenant);
+  applicationOrganizationRoutes(router, tenant);
+  applicationSecretRoutes(router, tenant);
+  applicationUserConsentScopeRoutes(router, tenant);
+  applicationSignInExperienceRoutes(router, tenant);
+  applicationUserConsentOrganizationRoutes(router, tenant);
 }
 /* eslint-enable max-lines */

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -5,7 +5,7 @@ import Router from 'koa-router';
 import { EnvSet } from '#src/env-set/index.js';
 import koaAuditLog from '#src/middleware/koa-audit-log.js';
 import koaBodyEtag from '#src/middleware/koa-body-etag.js';
-import { koaManagementApiHooks } from '#src/middleware/koa-management-api-hooks.js';
+import { koaApiHooks } from '#src/middleware/koa-api-hooks.js';
 import koaTenantGuard from '#src/middleware/koa-tenant-guard.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 
@@ -17,13 +17,6 @@ import { accountApiPrefix } from './account/constants.js';
 import accountRoutes from './account/index.js';
 import accountCentersRoutes from './account-center/index.js';
 import adminUserRoutes from './admin-user/index.js';
-import applicationOrganizationRoutes from './applications/application-organization.js';
-import applicationProtectedAppMetadataRoutes from './applications/application-protected-app-metadata.js';
-import applicationRoleRoutes from './applications/application-role.js';
-import applicationSecretRoutes from './applications/application-secret.js';
-import applicationSignInExperienceRoutes from './applications/application-sign-in-experience.js';
-import applicationUserConsentOrganizationRoutes from './applications/application-user-consent-organization.js';
-import applicationUserConsentScopeRoutes from './applications/application-user-consent-scope.js';
 import applicationRoutes from './applications/application.js';
 import authnRoutes from './authn.js';
 import captchaProviderRoutes from './captcha-provider/index.js';
@@ -72,19 +65,9 @@ const createRouters = (tenant: TenantContext) => {
   const managementRouter: ManagementApiRouter = new Router();
   managementRouter.use(koaAuth(tenant.envSet, getManagementApiResourceIndicator(tenant.id)));
   managementRouter.use(koaTenantGuard(tenant.id, tenant.queries));
-  managementRouter.use(koaManagementApiHooks(tenant.libraries.hooks));
+  managementRouter.use(koaApiHooks(tenant.libraries.hooks));
 
-  // TODO: FIXME @sijie @darcy mount these routes in `applicationRoutes` instead
   applicationRoutes(managementRouter, tenant);
-  applicationRoleRoutes(managementRouter, tenant);
-  applicationProtectedAppMetadataRoutes(managementRouter, tenant);
-  applicationOrganizationRoutes(managementRouter, tenant);
-  applicationSecretRoutes(managementRouter, tenant);
-
-  // Third-party application related routes
-  applicationUserConsentScopeRoutes(managementRouter, tenant);
-  applicationSignInExperienceRoutes(managementRouter, tenant);
-  applicationUserConsentOrganizationRoutes(managementRouter, tenant);
 
   logtoConfigRoutes(managementRouter, tenant);
   connectorRoutes(managementRouter, tenant);
@@ -116,8 +99,8 @@ const createRouters = (tenant: TenantContext) => {
 
   const userRouter: UserRouter = new Router();
   userRouter.use(koaOidcAuth(tenant));
-  // TODO(LOG-10147): Rename to koaApiHooks, this middleware is used for both management API and user API
-  userRouter.use(koaManagementApiHooks(tenant.libraries.hooks));
+  // TODO(LOG-10147): koaApiHooks middleware is used for both management API and user API
+  userRouter.use(koaApiHooks(tenant.libraries.hooks));
   accountRoutes(userRouter, tenant);
   verificationRoutes(userRouter, tenant);
 
@@ -138,8 +121,6 @@ const createRouters = (tenant: TenantContext) => {
     anonymousRouter,
     experienceRouter,
     userRouter,
-    // TODO: interactionRouter should be removed from swagger.json
-    interactionRouter,
   ]);
 
   return [experienceRouter, interactionRouter, managementRouter, anonymousRouter, userRouter];

--- a/packages/core/src/routes/organization/application/role-relations.ts
+++ b/packages/core/src/routes/organization/application/role-relations.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
-import { type WithHookContext } from '#src/middleware/koa-management-api-hooks.js';
+import { type WithHookContext } from '#src/middleware/koa-api-hooks.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import type OrganizationQueries from '#src/queries/organization/index.js';
 

--- a/packages/core/src/routes/organization/jit/email-domains.ts
+++ b/packages/core/src/routes/organization/jit/email-domains.ts
@@ -3,7 +3,7 @@ import type Router from 'koa-router';
 import { z } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
-import { type WithHookContext } from '#src/middleware/koa-management-api-hooks.js';
+import { type WithHookContext } from '#src/middleware/koa-api-hooks.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import type OrganizationQueries from '#src/queries/organization/index.js';
 

--- a/packages/core/src/routes/types.ts
+++ b/packages/core/src/routes/types.ts
@@ -4,7 +4,7 @@ import type Router from 'koa-router';
 import type { WithLogContext } from '#src/middleware/koa-audit-log.js';
 import type { WithAuthContext } from '#src/middleware/koa-auth/index.js';
 import type { WithI18nContext } from '#src/middleware/koa-i18next.js';
-import { type WithHookContext } from '#src/middleware/koa-management-api-hooks.js';
+import { type WithHookContext } from '#src/middleware/koa-api-hooks.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 
 import { type WithAccountCenterContext } from './account/middlewares/koa-account-center.js';

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import { type SearchOptions } from '#src/database/utils.js';
 import { buildManagementApiContext } from '#src/libraries/hook/utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
-import { type WithHookContext } from '#src/middleware/koa-management-api-hooks.js';
+import { type WithHookContext } from '#src/middleware/koa-api-hooks.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 
 import { type TwoRelationsQueries } from './RelationQueries.js';

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -62,7 +62,7 @@ export type InteractionHookEventPayload = {
 
 /**
  * The API context for management API triggered data hooks.
- * In the `koaManagementApiHooks` middleware,
+ * In the `koaApiHooks` middleware,
  * we will store the context of management API requests that triggers the DataHook events.
  * Can't put it in the DataHookMetadata because the matched API context is only available after the request is processed.
  */


### PR DESCRIPTION
## Summary
- rename `koaManagementApiHooks` to `koaApiHooks`
- mount application related routes inside `applicationRoutes`
- remove interaction router from Swagger generation
- update tests and docs

## Testing
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a048e4c832f90ef11bdb2688c90