### PR TITLE
Add flat eslint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '@silverhand',
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,6 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import eslintrc from './.eslintrc.cjs';
+
+const compat = new FlatCompat({ baseDirectory: import.meta.url });
+
+export default compat.config(eslintrc);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "//": "# `changeset version` won't run version lifecycle scripts, see https://github.com/changesets/changesets/issues/860",
     "ci:version": "changeset version && pnpm -r version",
     "ci:build": "pnpm -r build",
-    "ci:lint": "pnpm -r --parallel --workspace-concurrency=0 lint",
+    "ci:lint": "ESLINT_USE_FLAT_CONFIG=false pnpm -r --parallel --workspace-concurrency=0 lint",
     "ci:stylelint": "pnpm -r --parallel --workspace-concurrency=0 stylelint",
     "ci:test": "pnpm -r --parallel --workspace-concurrency=0 test:ci"
   },


### PR DESCRIPTION
## Summary
- add a root ESLint flat config
- call `pnpm ci:lint` with the legacy config flag

## Testing
- `pnpm ci:lint` *(fails: Error while loading rule @typescript-eslint/no-unnecessary-condition)*

------
https://chatgpt.com/codex/tasks/task_e_684cabef2098832faf558b271754a44d