### PR TITLE
feat: i18n for captcha provider errors

### DIFF
--- a/packages/core/src/queries/captcha-providers.ts
+++ b/packages/core/src/queries/captcha-providers.ts
@@ -8,6 +8,7 @@ import { generateStandardId } from '@logto/shared';
 import { type CommonQueryMethods } from '@silverhand/slonik';
 
 import SchemaQueries from '../utils/SchemaQueries.js';
+import RequestError from '#src/errors/RequestError/index.js';
 
 export class CaptchaProviderQueries extends SchemaQueries<
   CaptchaProviderKeys,
@@ -27,7 +28,10 @@ export class CaptchaProviderQueries extends SchemaQueries<
 
     if (providers.length > 1) {
       // Not expected to happen
-      throw new Error('Multiple captcha providers are not allowed.');
+      throw new RequestError({
+        code: 'captcha_provider.multiple_providers_not_allowed',
+        status: 500,
+      });
     }
 
     return providers[0];

--- a/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
@@ -8,6 +8,7 @@ import ky from 'ky';
 import { z } from 'zod';
 
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
+import RequestError from '#src/errors/RequestError/index.js';
 
 function isRecaptchaEnterprise(
   config: CaptchaProvider['config']
@@ -36,7 +37,10 @@ export class CaptchaValidator {
       return this.verifyTurnstile(config, captchaToken);
     }
 
-    throw new Error('Invalid captcha provider');
+    throw new RequestError({
+      code: 'captcha_provider.invalid_provider',
+      status: 500,
+    });
   }
 
   private async verifyTurnstile(config: TurnstileConfig, captchaToken: string) {

--- a/packages/phrases/src/locales/ar/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/ar/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/ar/errors/index.ts
+++ b/packages/phrases/src/locales/ar/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/de/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/de/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/de/errors/index.ts
+++ b/packages/phrases/src/locales/de/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/en/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/en/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/en/errors/index.ts
+++ b/packages/phrases/src/locales/en/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/es/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/es/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/es/errors/index.ts
+++ b/packages/phrases/src/locales/es/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/fr/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/fr/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/fr/errors/index.ts
+++ b/packages/phrases/src/locales/fr/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/it/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/it/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/it/errors/index.ts
+++ b/packages/phrases/src/locales/it/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/ja/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/ja/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/ja/errors/index.ts
+++ b/packages/phrases/src/locales/ja/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/ko/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/ko/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/ko/errors/index.ts
+++ b/packages/phrases/src/locales/ko/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/pl-pl/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/pl-pl/errors/index.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/pt-br/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/pt-br/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/pt-br/errors/index.ts
+++ b/packages/phrases/src/locales/pt-br/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/pt-pt/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/pt-pt/errors/index.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/ru/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/ru/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/ru/errors/index.ts
+++ b/packages/phrases/src/locales/ru/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/tr-tr/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/tr-tr/errors/index.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/zh-cn/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/zh-cn/errors/index.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/zh-hk/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/zh-hk/errors/index.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,6 +58,7 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
+  captcha_provider,
   custom_profile_fields,
 };
 

--- a/packages/phrases/src/locales/zh-tw/errors/captcha-provider.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/captcha-provider.ts
@@ -1,0 +1,6 @@
+const captcha_provider = {
+  multiple_providers_not_allowed: 'Multiple captcha providers are not allowed.',
+  invalid_provider: 'Invalid captcha provider.',
+};
+
+export default Object.freeze(captcha_provider);

--- a/packages/phrases/src/locales/zh-tw/errors/index.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/index.ts
@@ -7,6 +7,7 @@ import domain from './domain.js';
 import entity from './entity.js';
 import guard from './guard.js';
 import hook from './hook.js';
+import captcha_provider from './captcha-provider.js';
 import jwt_customizer from './jwt-customizer.js';
 import localization from './localization.js';
 import log from './log.js';
@@ -57,7 +58,9 @@ const errors = {
   verification_record,
   account_center,
   one_time_token,
-  custom_profile_fields,
+  captcha_provider,
+  captcha_provider,
+    custom_profile_fields,
 };
 
 export default Object.freeze(errors);


### PR DESCRIPTION
## Summary
- use RequestError when multiple captcha providers are found
- use RequestError for invalid captcha provider
- add captcha provider error phrases in all locales

## Testing
- `pnpm -r test:ci` *(fails: vitest not found)*
- `pnpm -r lint` *(fails: eslint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a0d4d04832f83311745b797116d