### PR TITLE
Update SAML auth flow

### DIFF
--- a/packages/core/src/routes/experience/verification-routes/social-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/social-verification.ts
@@ -57,7 +57,8 @@ export default function socialVerificationRoutes<T extends ExperienceInteraction
       const authorizationUri = await socialVerification.createAuthorizationUrl(
         ctx,
         tenantContext,
-        ctx.guard.body
+        ctx.guard.body,
+        'verificationRecord'
       );
 
       ctx.experienceInteraction.setVerificationRecord(socialVerification);
@@ -141,7 +142,12 @@ export default function socialVerificationRoutes<T extends ExperienceInteraction
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
       );
 
-      await socialVerificationRecord.verify(ctx, tenantContext, connectorData);
+      await socialVerificationRecord.verify(
+        ctx,
+        tenantContext,
+        connectorData,
+        'verificationRecord'
+      );
       // Skip captcha for social verification, as it's already verified by the connector
       ctx.experienceInteraction.skipCaptcha();
       await ctx.experienceInteraction.save();

--- a/packages/core/src/routes/interaction/additional.ts
+++ b/packages/core/src/routes/interaction/additional.ts
@@ -35,7 +35,7 @@ import {
   isSignInInteractionResult,
   storeInteractionResult,
 } from './utils/interaction.js';
-import { createSocialAuthorizationUrl } from './utils/social-verification.js';
+import { SocialVerification } from '../experience/classes/verifications/social-verification.js';
 import { generateTotpSecret } from './utils/totp-validation.js';
 import { sendVerificationCodeToIdentifier } from './utils/verification-code-validation.js';
 import {
@@ -106,7 +106,17 @@ export default function additionalRoutes<T extends IRouterParamContext>(
 
       log.append(payload);
 
-      const redirectTo = await createSocialAuthorizationUrl(ctx, tenant, payload);
+      const socialVerification = SocialVerification.create(
+        tenant.libraries,
+        tenant.queries,
+        payload.connectorId
+      );
+
+      const redirectTo = await socialVerification.createAuthorizationUrl(
+        ctx,
+        tenant,
+        payload
+      );
 
       ctx.body = { redirectTo };
 

--- a/packages/core/src/routes/interaction/utils/social-verification.ts
+++ b/packages/core/src/routes/interaction/utils/social-verification.ts
@@ -12,44 +12,6 @@ import assertThat from '#src/utils/assert-that.js';
 
 import type { SocialAuthorizationUrlPayload } from '../types/index.js';
 
-export const createSocialAuthorizationUrl = async (
-  ctx: WithLogContext,
-  { provider, connectors }: TenantContext,
-  payload: SocialAuthorizationUrlPayload
-) => {
-  const { getLogtoConnectorById } = connectors;
-
-  const { connectorId, state, redirectUri } = payload;
-  assertThat(state && redirectUri, 'session.insufficient_info');
-
-  const connector = await getLogtoConnectorById(connectorId);
-
-  assertThat(connector.type === ConnectorType.Social, 'connector.unexpected_type');
-
-  const {
-    headers: { 'user-agent': userAgent },
-  } = ctx.request;
-
-  const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
-
-  return connector.getAuthorizationUri(
-    {
-      state,
-      redirectUri,
-      /**
-       * For POST /authn/saml/:connectorId API, we need to block requests
-       * for non-SAML connector (relies on connectorFactoryId) and use `connectorId`
-       * to find correct connector config.
-       */
-      connectorId,
-      connectorFactoryId: connector.metadata.id,
-      jti,
-      headers: { userAgent },
-    },
-    async (connectorStorage: ConnectorSession) =>
-      assignConnectorSessionResult(ctx, provider, connectorStorage)
-  );
-};
 
 export const verifySocialIdentity = async (
   { connectorId, connectorData }: SocialConnectorPayload,


### PR DESCRIPTION
## Summary
- switch SAML handlers to social authorization session
- drop deprecated `createSocialAuthorizationUrl`
- use SocialVerification when starting social authorization

## Testing
- `pnpm -r test:ci` *(fails: vitest not found)*
- `pnpm -r lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a09f078832fa27bc0e12eb9c75c