### PR TITLE
Add score threshold to captcha config

### DIFF
--- a/packages/console/src/pages/CaptchaDetails/CaptchaContent/index.tsx
+++ b/packages/console/src/pages/CaptchaDetails/CaptchaContent/index.tsx
@@ -32,7 +32,10 @@ function CaptchaContent({ isDeleted, captchaProvider, onUpdate }: Props) {
     register,
   } = useForm<CaptchaFormType>({
     reValidateMode: 'onBlur',
-    defaultValues: captchaProvider.config,
+    defaultValues: {
+      ...captchaProvider.config,
+      scoreThreshold: captchaProvider.config.scoreThreshold ?? 0.5,
+    },
   });
 
   useEffect(() => {

--- a/packages/console/src/pages/Security/Captcha/CaptchaFormFields/index.tsx
+++ b/packages/console/src/pages/Security/Captcha/CaptchaFormFields/index.tsx
@@ -17,6 +17,7 @@ function CaptchaFormFields({ metadata, errors, register }: Props) {
   const siteKeyField = metadata.requiredFields.find((field) => field.field === 'siteKey');
   const secretKeyField = metadata.requiredFields.find((field) => field.field === 'secretKey');
   const projectIdField = metadata.requiredFields.find((field) => field.field === 'projectId');
+  const scoreField = metadata.requiredFields.find((field) => field.field === 'scoreThreshold');
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   return (
@@ -45,6 +46,19 @@ function CaptchaFormFields({ metadata, errors, register }: Props) {
             error={Boolean(errors.projectId)}
             placeholder={String(t(projectIdField.placeholder))}
             {...register('projectId', { required: true })}
+          />
+        </FormField>
+      )}
+      {scoreField && (
+        <FormField isRequired title={scoreField.label}>
+          <TextInput
+            error={Boolean(errors.scoreThreshold)}
+            type="number"
+            step="0.1"
+            min={0}
+            max={1}
+            placeholder={String(t(scoreField.placeholder))}
+            {...register('scoreThreshold', { valueAsNumber: true, required: true })}
           />
         </FormField>
       )}

--- a/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/constants.ts
+++ b/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/constants.ts
@@ -97,6 +97,11 @@ export const captchaProviders: CaptchaProviderMetadata[] = [
         label: 'security.captcha_details.project_id',
         placeholder: 'security.captcha_details.project_id',
       },
+      {
+        field: 'scoreThreshold',
+        label: 'security.captcha_details.score_threshold',
+        placeholder: 'security.captcha_details.score_threshold',
+      },
     ],
   },
   {

--- a/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/types.ts
+++ b/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/types.ts
@@ -1,7 +1,7 @@
 import { type AdminConsoleKey } from '@logto/phrases';
 import { type CaptchaType } from '@logto/schemas';
 
-type FormField = 'siteKey' | 'secretKey' | 'projectId';
+type FormField = 'siteKey' | 'secretKey' | 'projectId' | 'scoreThreshold';
 
 export type CaptchaProviderMetadata = {
   name: AdminConsoleKey;

--- a/packages/console/src/pages/Security/Captcha/Guide/index.tsx
+++ b/packages/console/src/pages/Security/Captcha/Guide/index.tsx
@@ -43,6 +43,7 @@ function Guide({ type, onClose }: Props) {
       siteKey: '',
       secretKey: '',
       projectId: '',
+      scoreThreshold: 0.5,
     },
   });
 

--- a/packages/console/src/pages/Security/Captcha/types.tsx
+++ b/packages/console/src/pages/Security/Captcha/types.tsx
@@ -2,4 +2,5 @@ export type CaptchaFormType = {
   siteKey: string;
   secretKey: string;
   projectId: string;
+  scoreThreshold?: number;
 };

--- a/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
@@ -108,8 +108,7 @@ export class CaptchaValidator {
         riskAnalysis: { score },
       } = responseGuard.parse(result);
 
-      // TODO: customize the score threshold
-      const success = valid && score >= 0.5;
+      const success = valid && score >= (config.scoreThreshold ?? 0.5);
 
       this.log.append({
         success,

--- a/packages/integration-tests/src/tests/api/captcha-provider.test.ts
+++ b/packages/integration-tests/src/tests/api/captcha-provider.test.ts
@@ -32,6 +32,7 @@ describe('captcha provider', () => {
         siteKey: 'site_key',
         secretKey: 'secret_key',
         projectId: 'project_id',
+        scoreThreshold: 0.7,
       },
     });
 
@@ -43,6 +44,7 @@ describe('captcha provider', () => {
         siteKey: 'site_key',
         secretKey: 'secret_key',
         projectId: 'project_id',
+        scoreThreshold: 0.7,
       },
     });
   });

--- a/packages/phrases/src/locales/en/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/security.ts
@@ -47,6 +47,7 @@ const security = {
     site_key: 'Site key',
     secret_key: 'Secret key',
     project_id: 'Project ID',
+    score_threshold: 'Score threshold',
     recaptcha_key_id: 'reCAPTCHA key ID',
     recaptcha_api_key: 'API key of the project',
     deletion_description: 'Are you sure you want to delete this CAPTCHA provider?',

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.29.0
+
+### Minor Changes
+
+- feat: allow tenants to configure acceptable CAPTCHA scores with `scoreThreshold` in reCAPTCHA Enterprise. Default value is `0.5`.
+
 ## 1.28.0
 
 ### Patch Changes

--- a/packages/schemas/src/foundations/jsonb-types/captcha.ts
+++ b/packages/schemas/src/foundations/jsonb-types/captcha.ts
@@ -18,6 +18,8 @@ export const recaptchaEnterpriseConfigGuard = z.object({
   siteKey: z.string(),
   secretKey: z.string(),
   projectId: z.string(),
+  /** The minimum acceptable score returned from reCAPTCHA Enterprise. */
+  scoreThreshold: z.number().min(0).max(1).optional().default(0.5),
 });
 
 export type RecaptchaEnterpriseConfig = z.infer<typeof recaptchaEnterpriseConfigGuard>;


### PR DESCRIPTION
## Summary
- add `scoreThreshold` to reCAPTCHA config and use it in captcha validator
- expose score threshold field in console forms
- document default value
- update integration tests for captcha provider

## Testing
- `pnpm ci:test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5a06fa08832fb051915df1ddba59