### PR TITLE
Remove temp guards and rename helpers

### DIFF
--- a/packages/integration-tests/src/api/account-center.ts
+++ b/packages/integration-tests/src/api/account-center.ts
@@ -1,14 +1,14 @@
 import { AccountCenterControlValue, type AccountCenter } from '@logto/schemas';
 import { type KyInstance } from 'ky';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
-export const getAccountCenter = async (api: KyInstance = authedAdminApi) =>
+export const getAccountCenter = async (api: KyInstance = authedApi) =>
   api.get('account-center').json<AccountCenter>();
 
 export const updateAccountCenter = async (
   accountCenter: Partial<AccountCenter>,
-  api: KyInstance = authedAdminApi
+  api: KyInstance = authedApi
 ) =>
   api
     .patch('account-center', {
@@ -16,7 +16,7 @@ export const updateAccountCenter = async (
     })
     .json<AccountCenter>();
 
-export const disableAccountCenter = async (api: KyInstance = authedAdminApi) => {
+export const disableAccountCenter = async (api: KyInstance = authedApi) => {
   await updateAccountCenter(
     {
       enabled: false,
@@ -26,7 +26,7 @@ export const disableAccountCenter = async (api: KyInstance = authedAdminApi) => 
   );
 };
 
-export const enableAllAccountCenterFields = async (api: KyInstance = authedAdminApi) => {
+export const enableAllAccountCenterFields = async (api: KyInstance = authedApi) => {
   await updateAccountCenter(
     {
       enabled: true,

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -13,7 +13,7 @@ import type {
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export type CreateUserPayload = Partial<{
   primaryEmail: string;
@@ -26,14 +26,14 @@ export type CreateUserPayload = Partial<{
 }>;
 
 export const createUser = async (payload: CreateUserPayload = {}) =>
-  authedAdminApi
+  authedApi
     .post('users', {
       json: payload,
     })
     .json<User>();
 
 export const getUser = async (userId: string, withSsoIdentities = false) =>
-  authedAdminApi
+  authedApi
     .get(
       `users/${userId}`,
       conditional(
@@ -42,29 +42,29 @@ export const getUser = async (userId: string, withSsoIdentities = false) =>
     )
     .json<User & { ssoIdentities?: UserSsoIdentity[] }>();
 
-export const getUsers = async () => authedAdminApi.get('users').json<User[]>();
+export const getUsers = async () => authedApi.get('users').json<User[]>();
 
 export const updateUser = async (userId: string, payload: Partial<User>) =>
-  authedAdminApi
+  authedApi
     .patch(`users/${userId}`, {
       json: payload,
     })
     .json<User>();
 
 export const updateUserProfile = async (userId: string, profile: Partial<User['profile']>) =>
-  authedAdminApi
+  authedApi
     .patch(`users/${userId}/profile`, {
       json: { profile },
     })
     .json<User['profile']>();
 
 export const suspendUser = async (userId: string, isSuspended: boolean) =>
-  authedAdminApi.patch(`users/${userId}/is-suspended`, { json: { isSuspended } }).json<User>();
+  authedApi.patch(`users/${userId}/is-suspended`, { json: { isSuspended } }).json<User>();
 
-export const deleteUser = async (userId: string) => authedAdminApi.delete(`users/${userId}`);
+export const deleteUser = async (userId: string) => authedApi.delete(`users/${userId}`);
 
 export const updateUserPassword = async (userId: string, password: string) =>
-  authedAdminApi
+  authedApi
     .patch(`users/${userId}/password`, {
       json: {
         password,
@@ -73,13 +73,13 @@ export const updateUserPassword = async (userId: string, password: string) =>
     .json<User>();
 
 export const deleteUserIdentity = async (userId: string, connectorTarget: string) =>
-  authedAdminApi.delete(`users/${userId}/identities/${connectorTarget}`);
+  authedApi.delete(`users/${userId}/identities/${connectorTarget}`);
 
 export const assignRolesToUser = async (userId: string, roleIds: string[]) =>
-  authedAdminApi.post(`users/${userId}/roles`, { json: { roleIds } });
+  authedApi.post(`users/${userId}/roles`, { json: { roleIds } });
 
 export const putRolesToUser = async (userId: string, roleIds: string[]) =>
-  authedAdminApi.put(`users/${userId}/roles`, { json: { roleIds } });
+  authedApi.put(`users/${userId}/roles`, { json: { roleIds } });
 
 /**
  * Get roles assigned to the user.
@@ -90,18 +90,18 @@ export const putRolesToUser = async (userId: string, roleIds: string[]) =>
  */
 export const getUserRoles = async (userId: string, keyword?: string) => {
   const searchParams = new URLSearchParams(keyword && [['search', `%${keyword}%`]]);
-  return authedAdminApi.get(`users/${userId}/roles`, { searchParams }).json<Role[]>();
+  return authedApi.get(`users/${userId}/roles`, { searchParams }).json<Role[]>();
 };
 
 export const deleteRoleFromUser = async (userId: string, roleId: string) =>
-  authedAdminApi.delete(`users/${userId}/roles/${roleId}`);
+  authedApi.delete(`users/${userId}/roles/${roleId}`);
 
 export const postUserIdentity = async (
   userId: string,
   connectorId: string,
   connectorData: Record<string, unknown>
 ) =>
-  authedAdminApi
+  authedApi
     .post(`users/${userId}/identities`, {
       json: {
         connectorId,
@@ -111,19 +111,19 @@ export const postUserIdentity = async (
     .json<Identities>();
 
 export const putUserIdentity = async (userId: string, target: string, identity: Identity) =>
-  authedAdminApi.put(`users/${userId}/identities/${target}`, { json: identity }).json<Identities>();
+  authedApi.put(`users/${userId}/identities/${target}`, { json: identity }).json<Identities>();
 
 export const verifyUserPassword = async (userId: string, password: string) =>
-  authedAdminApi.post(`users/${userId}/password/verify`, { json: { password } });
+  authedApi.post(`users/${userId}/password/verify`, { json: { password } });
 
 export const getUserMfaVerifications = async (userId: string) =>
-  authedAdminApi.get(`users/${userId}/mfa-verifications`).json<MfaVerification[]>();
+  authedApi.get(`users/${userId}/mfa-verifications`).json<MfaVerification[]>();
 
 export const deleteUserMfaVerification = async (userId: string, mfaVerificationId: string) =>
-  authedAdminApi.delete(`users/${userId}/mfa-verifications/${mfaVerificationId}`);
+  authedApi.delete(`users/${userId}/mfa-verifications/${mfaVerificationId}`);
 
 export const createUserMfaVerification = async (userId: string, type: MfaFactor) =>
-  authedAdminApi
+  authedApi
     .post(`users/${userId}/mfa-verifications`, { json: { type } })
     .json<
       | { type: MfaFactor.TOTP; secret: string; secretQrCode: string }
@@ -131,28 +131,28 @@ export const createUserMfaVerification = async (userId: string, type: MfaFactor)
     >();
 
 export const getUserOrganizations = async (userId: string) =>
-  authedAdminApi.get(`users/${userId}/organizations`).json<OrganizationWithRoles[]>();
+  authedApi.get(`users/${userId}/organizations`).json<OrganizationWithRoles[]>();
 
 export const createPersonalAccessToken = async ({
   userId,
   ...body
 }: Omit<CreatePersonalAccessToken, 'value'>) =>
-  authedAdminApi
+  authedApi
     .post(`users/${userId}/personal-access-tokens`, { json: body })
     .json<PersonalAccessToken>();
 
 export const getUserPersonalAccessTokens = async (userId: string) =>
-  authedAdminApi.get(`users/${userId}/personal-access-tokens`).json<PersonalAccessToken[]>();
+  authedApi.get(`users/${userId}/personal-access-tokens`).json<PersonalAccessToken[]>();
 
 export const deletePersonalAccessToken = async (userId: string, name: string) =>
-  authedAdminApi.delete(`users/${userId}/personal-access-tokens/${name}`);
+  authedApi.delete(`users/${userId}/personal-access-tokens/${name}`);
 
 export const updatePersonalAccessToken = async (
   userId: string,
   name: string,
   body: Record<string, unknown>
 ) =>
-  authedAdminApi
+  authedApi
     .patch(`users/${userId}/personal-access-tokens/${name}`, {
       json: body,
     })

--- a/packages/integration-tests/src/api/api.ts
+++ b/packages/integration-tests/src/api/api.ts
@@ -14,8 +14,7 @@ export const baseApi = ky.extend({
   prefixUrl: new URL(logtoUrl),
 });
 
-// TODO: @gao rename
-export const authedAdminApi = api.extend({
+export const authedApi = api.extend({
   headers: {
     'development-user-id': 'integration-test-admin-user',
   },

--- a/packages/integration-tests/src/api/application-sign-in-experience.ts
+++ b/packages/integration-tests/src/api/application-sign-in-experience.ts
@@ -3,17 +3,17 @@ import {
   type ApplicationSignInExperience,
 } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const setApplicationSignInExperience = async (
   applicationId: string,
   payload: ApplicationSignInExperienceCreate
 ) =>
-  authedAdminApi
+  authedApi
     .put(`applications/${applicationId}/sign-in-experience`, { json: payload })
     .json<ApplicationSignInExperience>();
 
 export const getApplicationSignInExperience = async (applicationId: string) =>
-  authedAdminApi
+  authedApi
     .get(`applications/${applicationId}/sign-in-experience`)
     .json<ApplicationSignInExperience>();

--- a/packages/integration-tests/src/api/application-user-consent-organization.ts
+++ b/packages/integration-tests/src/api/application-user-consent-organization.ts
@@ -1,6 +1,6 @@
 import { type Organization } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const postApplicationUserConsentOrganization = async (
   applicationId: string,
@@ -9,7 +9,7 @@ export const postApplicationUserConsentOrganization = async (
     organizationIds: string[];
   }
 ) =>
-  authedAdminApi.post(`applications/${applicationId}/users/${userId}/consent-organizations`, {
+  authedApi.post(`applications/${applicationId}/users/${userId}/consent-organizations`, {
     json: payload,
   });
 
@@ -20,7 +20,7 @@ export const putApplicationUserConsentOrganization = async (
     organizationIds: string[];
   }
 ) =>
-  authedAdminApi.put(`applications/${applicationId}/users/${userId}/consent-organizations`, {
+  authedApi.put(`applications/${applicationId}/users/${userId}/consent-organizations`, {
     json: payload,
   });
 
@@ -28,7 +28,7 @@ export const getApplicationUserConsentOrganization = async (
   applicationId: string,
   userId: string
 ) =>
-  authedAdminApi.get(`applications/${applicationId}/users/${userId}/consent-organizations`).json<{
+  authedApi.get(`applications/${applicationId}/users/${userId}/consent-organizations`).json<{
     organizations: Organization[];
   }>();
 
@@ -37,6 +37,6 @@ export const deleteApplicationUserConsentOrganization = async (
   userId: string,
   organizationId: string
 ) =>
-  authedAdminApi.delete(
+  authedApi.delete(
     `applications/${applicationId}/users/${userId}/consent-organizations/${organizationId}`
   );

--- a/packages/integration-tests/src/api/application-user-consent-scope.ts
+++ b/packages/integration-tests/src/api/application-user-consent-scope.ts
@@ -4,7 +4,7 @@ import {
   type ApplicationUserConsentScopesResponse,
 } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const assignUserConsentScopes = async (
   applicationId: string,
@@ -14,10 +14,10 @@ export const assignUserConsentScopes = async (
     organizationResourceScopes?: string[];
     userScopes?: UserScope[];
   }
-) => authedAdminApi.post(`applications/${applicationId}/user-consent-scopes`, { json: payload });
+) => authedApi.post(`applications/${applicationId}/user-consent-scopes`, { json: payload });
 
 export const getUserConsentScopes = async (applicationId: string) =>
-  authedAdminApi
+  authedApi
     .get(`applications/${applicationId}/user-consent-scopes`)
     .json<ApplicationUserConsentScopesResponse>();
 
@@ -26,6 +26,6 @@ export const deleteUserConsentScopes = async (
   scopeType: ApplicationUserConsentScopeType,
   scopeId: string
 ) =>
-  authedAdminApi.delete(
+  authedApi.delete(
     `applications/${applicationId}/user-consent-scopes/${scopeType}/${scopeId}`
   );

--- a/packages/integration-tests/src/api/application.ts
+++ b/packages/integration-tests/src/api/application.ts
@@ -11,7 +11,7 @@ import {
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 
-import { authedAdminApi, oidcApi } from './api.js';
+import { authedApi, oidcApi } from './api.js';
 
 export const createApplication = async (
   name: string,
@@ -23,7 +23,7 @@ export const createApplication = async (
     }
   >
 ) =>
-  authedAdminApi
+  authedApi
     .post('applications', {
       json: {
         name,
@@ -48,11 +48,11 @@ export const getApplications = async (
     ...(conditional(isThirdParty && [['isThirdParty', isThirdParty]]) ?? []),
   ]);
 
-  return authedAdminApi.get('applications', { searchParams }).json<Application[]>();
+  return authedApi.get('applications', { searchParams }).json<Application[]>();
 };
 
 export const getApplication = async (applicationId: string) =>
-  authedAdminApi.get(`applications/${applicationId}`).json<Application & { isAdmin: boolean }>();
+  authedApi.get(`applications/${applicationId}`).json<Application & { isAdmin: boolean }>();
 
 export const updateApplication = async (
   applicationId: string,
@@ -62,7 +62,7 @@ export const updateApplication = async (
     } & { protectedAppMetadata: Partial<ProtectedAppMetadata> }
   > & { isAdmin?: boolean }
 ) =>
-  authedAdminApi
+  authedApi
     .patch(`applications/${applicationId}`, {
       json: {
         ...payload,
@@ -71,7 +71,7 @@ export const updateApplication = async (
     .json<Application>();
 
 export const deleteApplication = async (applicationId: string) =>
-  authedAdminApi.delete(`applications/${applicationId}`);
+  authedApi.delete(`applications/${applicationId}`);
 
 /**
  * Get roles assigned to the m2m app.
@@ -82,21 +82,21 @@ export const deleteApplication = async (applicationId: string) =>
  */
 export const getApplicationRoles = async (applicationId: string, keyword?: string) => {
   const searchParams = new URLSearchParams(conditional(keyword && [['search', `%${keyword}%`]]));
-  return authedAdminApi.get(`applications/${applicationId}/roles`, { searchParams }).json<Role[]>();
+  return authedApi.get(`applications/${applicationId}/roles`, { searchParams }).json<Role[]>();
 };
 
 export const assignRolesToApplication = async (applicationId: string, roleIds: string[]) =>
-  authedAdminApi.post(`applications/${applicationId}/roles`, {
+  authedApi.post(`applications/${applicationId}/roles`, {
     json: { roleIds },
   });
 
 export const putRolesToApplication = async (applicationId: string, roleIds: string[]) =>
-  authedAdminApi.put(`applications/${applicationId}/roles`, {
+  authedApi.put(`applications/${applicationId}/roles`, {
     json: { roleIds },
   });
 
 export const deleteRoleFromApplication = async (applicationId: string, roleId: string) =>
-  authedAdminApi.delete(`applications/${applicationId}/roles/${roleId}`);
+  authedApi.delete(`applications/${applicationId}/roles/${roleId}`);
 
 export const generateM2mLog = async (applicationId: string) => {
   const { id, secret, type, isThirdParty } = await getApplication(applicationId);
@@ -127,7 +127,7 @@ export const getOrganizations = async (applicationId: string, page?: number, pag
     searchParams.append('page_size', String(pageSize));
   }
 
-  return authedAdminApi
+  return authedApi
     .get(`applications/${applicationId}/organizations`, {
       searchParams,
     })
@@ -138,35 +138,35 @@ export const createApplicationSecret = async ({
   applicationId,
   ...body
 }: Omit<CreateApplicationSecret, 'value'>) =>
-  authedAdminApi
+  authedApi
     .post(`applications/${applicationId}/secrets`, { json: body })
     .json<ApplicationSecret>();
 
 export const getApplicationSecrets = async (applicationId: string) =>
-  authedAdminApi.get(`applications/${applicationId}/secrets`).json<ApplicationSecret[]>();
+  authedApi.get(`applications/${applicationId}/secrets`).json<ApplicationSecret[]>();
 
 export const deleteApplicationSecret = async (applicationId: string, secretName: string) =>
-  authedAdminApi.delete(`applications/${applicationId}/secrets/${secretName}`);
+  authedApi.delete(`applications/${applicationId}/secrets/${secretName}`);
 
 export const updateApplicationSecret = async (
   applicationId: string,
   secretName: string,
   body: Record<string, unknown>
 ) =>
-  authedAdminApi
+  authedApi
     .patch(`applications/${applicationId}/secrets/${secretName}`, {
       json: body,
     })
     .json<ApplicationSecret>();
 
 export const deleteLegacyApplicationSecret = async (applicationId: string) =>
-  authedAdminApi.delete(`applications/${applicationId}/legacy-secret`);
+  authedApi.delete(`applications/${applicationId}/legacy-secret`);
 
 export const patchApplicationCustomData = async (
   applicationId: string,
   customData: Record<string, unknown>
 ) => {
-  return authedAdminApi
+  return authedApi
     .patch(`applications/${applicationId}/custom-data`, {
       json: customData,
     })

--- a/packages/integration-tests/src/api/captcha-provider.ts
+++ b/packages/integration-tests/src/api/captcha-provider.ts
@@ -1,14 +1,14 @@
 import { type CaptchaProvider } from '@logto/schemas';
 import { type KyInstance } from 'ky';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
-export const getCaptchaProvider = async (api: KyInstance = authedAdminApi) =>
+export const getCaptchaProvider = async (api: KyInstance = authedApi) =>
   api.get('captcha-provider').json<CaptchaProvider>();
 
 export const updateCaptchaProvider = async (
   captchaProvider: Partial<CaptchaProvider>,
-  api: KyInstance = authedAdminApi
+  api: KyInstance = authedApi
 ) =>
   api
     .put('captcha-provider', {
@@ -16,5 +16,5 @@ export const updateCaptchaProvider = async (
     })
     .json<CaptchaProvider>();
 
-export const deleteCaptchaProvider = async (api: KyInstance = authedAdminApi) =>
+export const deleteCaptchaProvider = async (api: KyInstance = authedApi) =>
   api.delete('captcha-provider').json<CaptchaProvider>();

--- a/packages/integration-tests/src/api/connector.ts
+++ b/packages/integration-tests/src/api/connector.ts
@@ -6,7 +6,7 @@ import type {
 } from '@logto/schemas';
 import { type KyInstance } from 'ky';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 /**
  * We are using `id` and `connectorFactoryId` here:
@@ -16,23 +16,23 @@ import { authedAdminApi } from './api.js';
  * that contain metadata (considered connectors' FIXED properties) and code implementation (which determines how connectors work).
  */
 
-export const listConnectors = async (api: KyInstance = authedAdminApi) =>
+export const listConnectors = async (api: KyInstance = authedApi) =>
   api.get('connectors').json<ConnectorResponse[]>();
 
-export const getConnector = async (id: string, api: KyInstance = authedAdminApi) =>
+export const getConnector = async (id: string, api: KyInstance = authedApi) =>
   api.get(`connectors/${id}`).json<ConnectorResponse>();
 
-export const listConnectorFactories = async (api: KyInstance = authedAdminApi) =>
+export const listConnectorFactories = async (api: KyInstance = authedApi) =>
   api.get('connector-factories').json<ConnectorFactoryResponse[]>();
 
 export const getConnectorFactory = async (
   connectorFactoryId: string,
-  api: KyInstance = authedAdminApi
+  api: KyInstance = authedApi
 ) => api.get(`connector-factories/${connectorFactoryId}`).json<ConnectorFactoryResponse>();
 
 export const postConnector = async (
   payload: Pick<CreateConnector, 'connectorId' | 'config' | 'metadata' | 'syncProfile'>,
-  api: KyInstance = authedAdminApi
+  api: KyInstance = authedApi
 ) =>
   api
     .post('connectors', {
@@ -40,7 +40,7 @@ export const postConnector = async (
     })
     .json<Connector>();
 
-export const deleteConnectorById = async (id: string, api: KyInstance = authedAdminApi) =>
+export const deleteConnectorById = async (id: string, api: KyInstance = authedApi) =>
   api.delete(`connectors/${id}`).json();
 
 export const updateConnectorConfig = async (
@@ -48,7 +48,7 @@ export const updateConnectorConfig = async (
   config: Record<string, unknown>,
   metadata?: Record<string, unknown>
 ) =>
-  authedAdminApi
+  authedApi
     .patch(`connectors/${id}`, {
       json: { config, metadata },
     })
@@ -74,7 +74,7 @@ const sendTestMessage = async (
   config: Record<string, unknown>,
   locale?: string
 ) =>
-  authedAdminApi.post(`connectors/${connectorFactoryId}/test`, {
+  authedApi.post(`connectors/${connectorFactoryId}/test`, {
     json: { [receiverType]: receiver, config, locale },
   });
 
@@ -82,7 +82,7 @@ export const getConnectorAuthorizationUri = async (
   connectorId: string,
   state: string,
   redirectUri: string,
-  api: KyInstance = authedAdminApi
+  api: KyInstance = authedApi
 ) =>
   api
     .post(`connectors/${connectorId}/authorization-uri`, {

--- a/packages/integration-tests/src/api/custom-phrase.ts
+++ b/packages/integration-tests/src/api/custom-phrase.ts
@@ -1,15 +1,15 @@
 import type { CustomPhrase, Translation } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const listCustomPhrases = async () =>
-  authedAdminApi.get('custom-phrases').json<CustomPhrase[]>();
+  authedApi.get('custom-phrases').json<CustomPhrase[]>();
 
 export const getCustomPhrase = async (languageTag: string) =>
-  authedAdminApi.get(`custom-phrases/${languageTag}`).json<CustomPhrase>();
+  authedApi.get(`custom-phrases/${languageTag}`).json<CustomPhrase>();
 
 export const createOrUpdateCustomPhrase = async (languageTag: string, translation: Translation) =>
-  authedAdminApi.put(`custom-phrases/${languageTag}`, { json: translation }).json<CustomPhrase>();
+  authedApi.put(`custom-phrases/${languageTag}`, { json: translation }).json<CustomPhrase>();
 
 export const deleteCustomPhrase = async (languageTag: string) =>
-  authedAdminApi.delete(`custom-phrases/${languageTag}`).json();
+  authedApi.delete(`custom-phrases/${languageTag}`).json();

--- a/packages/integration-tests/src/api/dashboard.ts
+++ b/packages/integration-tests/src/api/dashboard.ts
@@ -1,4 +1,4 @@
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export type StatisticsData = {
   count: number;
@@ -22,10 +22,10 @@ export type ActiveUserStatistics = {
 };
 
 export const getTotalUsersCount = async () =>
-  authedAdminApi.get('dashboard/users/total').json<TotalUserCountData>();
+  authedApi.get('dashboard/users/total').json<TotalUserCountData>();
 
 export const getNewUsersData = async () =>
-  authedAdminApi.get('dashboard/users/new').json<NewUserStatistics>();
+  authedApi.get('dashboard/users/new').json<NewUserStatistics>();
 
 export const getActiveUsersData = async () =>
-  authedAdminApi.get('dashboard/users/active').json<ActiveUserStatistics>();
+  authedApi.get('dashboard/users/active').json<ActiveUserStatistics>();

--- a/packages/integration-tests/src/api/domain.ts
+++ b/packages/integration-tests/src/api/domain.ts
@@ -2,10 +2,10 @@ import type { DomainResponse } from '@logto/schemas';
 
 import { generateDomain } from '#src/utils.js';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const createDomain = async (domain?: string) =>
-  authedAdminApi
+  authedApi
     .post('domains', {
       json: {
         domain: domain ?? generateDomain(),
@@ -13,10 +13,10 @@ export const createDomain = async (domain?: string) =>
     })
     .json<DomainResponse>();
 
-export const getDomains = async () => authedAdminApi.get('domains').json<DomainResponse[]>();
+export const getDomains = async () => authedApi.get('domains').json<DomainResponse[]>();
 
 export const getDomain = async (domainId: string) =>
-  authedAdminApi.get(`domains/${domainId}`).json<DomainResponse>();
+  authedApi.get(`domains/${domainId}`).json<DomainResponse>();
 
 export const deleteDomain = async (domainId: string) =>
-  authedAdminApi.delete(`domains/${domainId}`);
+  authedApi.delete(`domains/${domainId}`);

--- a/packages/integration-tests/src/api/email-templates.ts
+++ b/packages/integration-tests/src/api/email-templates.ts
@@ -4,39 +4,39 @@ import {
   type EmailTemplate,
 } from '@logto/schemas';
 
-import { authedAdminApi } from './index.js';
+import { authedApi } from './index.js';
 
 const path = 'email-templates';
 
 export class EmailTemplatesApi {
   async create(templates: Array<Omit<CreateEmailTemplate, 'id'>>): Promise<EmailTemplate[]> {
-    return authedAdminApi.put(path, { json: { templates } }).json<EmailTemplate[]>();
+    return authedApi.put(path, { json: { templates } }).json<EmailTemplate[]>();
   }
 
   async delete(id: string): Promise<void> {
-    await authedAdminApi.delete(`${path}/${id}`);
+    await authedApi.delete(`${path}/${id}`);
   }
 
   async findById(id: string): Promise<EmailTemplate> {
-    return authedAdminApi.get(`${path}/${id}`).json<EmailTemplate>();
+    return authedApi.get(`${path}/${id}`).json<EmailTemplate>();
   }
 
   async findAll(
     where?: Partial<Pick<EmailTemplate, 'languageTag' | 'templateType'>>
   ): Promise<EmailTemplate[]> {
-    return authedAdminApi.get(path, { searchParams: where }).json<EmailTemplate[]>();
+    return authedApi.get(path, { searchParams: where }).json<EmailTemplate[]>();
   }
 
   async updateTemplateDetailsById(
     id: string,
     details: Partial<EmailTemplateDetails>
   ): Promise<EmailTemplate> {
-    return authedAdminApi.patch(`${path}/${id}/details`, { json: details }).json<EmailTemplate>();
+    return authedApi.patch(`${path}/${id}/details`, { json: details }).json<EmailTemplate>();
   }
 
   async deleteMany(
     where: Partial<Pick<EmailTemplate, 'languageTag' | 'templateType'>>
   ): Promise<{ rowCount: number }> {
-    return authedAdminApi.delete(path, { searchParams: where }).json<{ rowCount: number }>();
+    return authedApi.delete(path, { searchParams: where }).json<{ rowCount: number }>();
   }
 }

--- a/packages/integration-tests/src/api/factory.ts
+++ b/packages/integration-tests/src/api/factory.ts
@@ -1,4 +1,4 @@
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 /**
  * Transform the data to a new object or array without modifying the original data.
@@ -26,27 +26,27 @@ export class ApiFactory<
   constructor(public readonly path: string) {}
 
   async create(data: PostData): Promise<Schema> {
-    return transform(await authedAdminApi.post(this.path, { json: data }).json<Schema>());
+    return transform(await authedApi.post(this.path, { json: data }).json<Schema>());
   }
 
   async getList(params?: URLSearchParams): Promise<Schema[]> {
     return transform(
-      await authedAdminApi.get(this.path + '?' + (params?.toString() ?? '')).json<Schema[]>()
+      await authedApi.get(this.path + '?' + (params?.toString() ?? '')).json<Schema[]>()
     );
   }
 
   async get(id: string): Promise<Schema> {
-    return transform(await authedAdminApi.get(this.path + '/' + id).json<Schema>());
+    return transform(await authedApi.get(this.path + '/' + id).json<Schema>());
   }
 
   async update(id: string, data: PatchData): Promise<Schema> {
     return transform(
-      await authedAdminApi.patch(this.path + '/' + id, { json: data }).json<Schema>()
+      await authedApi.patch(this.path + '/' + id, { json: data }).json<Schema>()
     );
   }
 
   async delete(id: string): Promise<void> {
-    await authedAdminApi.delete(this.path + '/' + id);
+    await authedApi.delete(this.path + '/' + id);
   }
 }
 
@@ -103,24 +103,24 @@ export class RelationApiFactory<RelationSchema extends Record<string, unknown>> 
     }
 
     return transform(
-      await authedAdminApi
+      await authedApi
         .get(`${this.basePath}/${id}/${this.relationPath}`, { searchParams })
         .json<RelationSchema[]>()
     );
   }
 
   async add(id: string, relationIds: string[]): Promise<void> {
-    await authedAdminApi.post(`${this.basePath}/${id}/${this.relationPath}`, {
+    await authedApi.post(`${this.basePath}/${id}/${this.relationPath}`, {
       json: { [this.relationKey]: relationIds },
     });
   }
 
   async delete(id: string, relationId: string): Promise<void> {
-    await authedAdminApi.delete(`${this.basePath}/${id}/${this.relationPath}/${relationId}`);
+    await authedApi.delete(`${this.basePath}/${id}/${this.relationPath}/${relationId}`);
   }
 
   async replace(id: string, relationIds: string[]): Promise<void> {
-    await authedAdminApi.put(`${this.basePath}/${id}/${this.relationPath}`, {
+    await authedApi.put(`${this.basePath}/${id}/${this.relationPath}`, {
       json: { [this.relationKey]: relationIds },
     });
   }

--- a/packages/integration-tests/src/api/index.ts
+++ b/packages/integration-tests/src/api/index.ts
@@ -9,4 +9,4 @@ export * from './interaction.js';
 export * from './logto-config.js';
 export * from './domain.js';
 
-export { default as api, authedAdminApi, adminTenantApi } from './api.js';
+export { default as api, authedApi, adminTenantApi } from './api.js';

--- a/packages/integration-tests/src/api/logs.ts
+++ b/packages/integration-tests/src/api/logs.ts
@@ -1,14 +1,14 @@
 import type { Log } from '@logto/schemas';
 import { conditionalString } from '@silverhand/essentials';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const getAuditLogs = async (params?: URLSearchParams) =>
-  authedAdminApi.get('logs?' + conditionalString(params?.toString())).json<Log[]>();
+  authedApi.get('logs?' + conditionalString(params?.toString())).json<Log[]>();
 
 export const getWebhookRecentLogs = async (hookId: string, params?: URLSearchParams) =>
-  authedAdminApi
+  authedApi
     .get(`hooks/${hookId}/recent-logs?` + conditionalString(params?.toString()))
     .json<Log[]>();
 
-export const getLog = async (logId: string) => authedAdminApi.get(`logs/${logId}`).json<Log>();
+export const getLog = async (logId: string) => authedApi.get(`logs/${logId}`).json<Log>();

--- a/packages/integration-tests/src/api/logto-config.ts
+++ b/packages/integration-tests/src/api/logto-config.ts
@@ -10,29 +10,29 @@ import {
   type Json,
 } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const getAdminConsoleConfig = async () =>
-  authedAdminApi.get('configs/admin-console').json<AdminConsoleData>();
+  authedApi.get('configs/admin-console').json<AdminConsoleData>();
 
 export const updateAdminConsoleConfig = async (payload: Partial<AdminConsoleData>) =>
-  authedAdminApi
+  authedApi
     .patch(`configs/admin-console`, {
       json: payload,
     })
     .json<AdminConsoleData>();
 
 export const getOidcKeys = async (keyType: LogtoOidcConfigKeyType) =>
-  authedAdminApi.get(`configs/oidc/${keyType}`).json<OidcConfigKeysResponse[]>();
+  authedApi.get(`configs/oidc/${keyType}`).json<OidcConfigKeysResponse[]>();
 
 export const deleteOidcKey = async (keyType: LogtoOidcConfigKeyType, id: string) =>
-  authedAdminApi.delete(`configs/oidc/${keyType}/${id}`);
+  authedApi.delete(`configs/oidc/${keyType}/${id}`);
 
 export const rotateOidcKeys = async (
   keyType: LogtoOidcConfigKeyType,
   signingKeyAlgorithm: SupportedSigningKeyAlgorithm = SupportedSigningKeyAlgorithm.EC
 ) =>
-  authedAdminApi
+  authedApi
     .post(`configs/oidc/${keyType}/rotate`, { json: { signingKeyAlgorithm } })
     .json<OidcConfigKeysResponse[]>();
 
@@ -40,31 +40,31 @@ export const upsertJwtCustomizer = async (
   keyTypePath: 'access-token' | 'client-credentials',
   value: unknown
 ) =>
-  authedAdminApi
+  authedApi
     .put(`configs/jwt-customizer/${keyTypePath}`, { json: value })
     .json<AccessTokenJwtCustomizer | ClientCredentialsJwtCustomizer>();
 
 export const getJwtCustomizer = async (keyTypePath: 'access-token' | 'client-credentials') =>
-  authedAdminApi
+  authedApi
     .get(`configs/jwt-customizer/${keyTypePath}`)
     .json<AccessTokenJwtCustomizer | ClientCredentialsJwtCustomizer>();
 
 export const getJwtCustomizers = async () =>
-  authedAdminApi.get(`configs/jwt-customizer`).json<JwtCustomizerConfigs[]>();
+  authedApi.get(`configs/jwt-customizer`).json<JwtCustomizerConfigs[]>();
 
 export const deleteJwtCustomizer = async (keyTypePath: 'access-token' | 'client-credentials') =>
-  authedAdminApi.delete(`configs/jwt-customizer/${keyTypePath}`);
+  authedApi.delete(`configs/jwt-customizer/${keyTypePath}`);
 
 export const updateJwtCustomizer = async (
   keyTypePath: 'access-token' | 'client-credentials',
   value: unknown
 ) =>
-  authedAdminApi
+  authedApi
     .patch(`configs/jwt-customizer/${keyTypePath}`, { json: value })
     .json<AccessTokenJwtCustomizer | ClientCredentialsJwtCustomizer>();
 
 export const testJwtCustomizer = async (payload: JwtCustomizerTestRequestBody) =>
-  authedAdminApi
+  authedApi
     .post(`configs/jwt-customizer/test`, {
       json: payload,
     })

--- a/packages/integration-tests/src/api/one-time-token.ts
+++ b/packages/integration-tests/src/api/one-time-token.ts
@@ -1,12 +1,12 @@
 import { type OneTimeTokenStatus, type OneTimeToken } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export type CreateOneTimeToken = Pick<OneTimeToken, 'email'> &
   Partial<Pick<OneTimeToken, 'context'>> & { expiresIn?: number };
 
 export const createOneTimeToken = async (createOneTimeToken: CreateOneTimeToken) =>
-  authedAdminApi
+  authedApi
     .post('one-time-tokens', {
       json: createOneTimeToken,
     })
@@ -15,24 +15,24 @@ export const createOneTimeToken = async (createOneTimeToken: CreateOneTimeToken)
 export const verifyOneTimeToken = async (
   verifyOneTimeToken: Pick<OneTimeToken, 'email' | 'token'>
 ) =>
-  authedAdminApi
+  authedApi
     .post('one-time-tokens/verify', {
       json: verifyOneTimeToken,
     })
     .json<OneTimeToken>();
 
 export const getOneTimeTokenById = async (id: string) =>
-  authedAdminApi.get(`one-time-tokens/${id}`).json<OneTimeToken>();
+  authedApi.get(`one-time-tokens/${id}`).json<OneTimeToken>();
 
 export const updateOneTimeTokenStatus = async (id: string, status: OneTimeTokenStatus) =>
-  authedAdminApi
+  authedApi
     .put(`one-time-tokens/${id}/status`, {
       json: { status },
     })
     .json<OneTimeToken>();
 
 export const deleteOneTimeTokenById = async (id: string) =>
-  authedAdminApi.delete(`one-time-tokens/${id}`).json<OneTimeToken>();
+  authedApi.delete(`one-time-tokens/${id}`).json<OneTimeToken>();
 
 export const getOneTimeTokens = async (searchParams?: Record<string, string>) =>
-  authedAdminApi.get('one-time-tokens', { searchParams }).json<OneTimeToken[]>();
+  authedApi.get('one-time-tokens', { searchParams }).json<OneTimeToken[]>();

--- a/packages/integration-tests/src/api/organization-invitation.ts
+++ b/packages/integration-tests/src/api/organization-invitation.ts
@@ -4,7 +4,7 @@ import {
   type OrganizationInvitationEntity,
 } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 import { ApiFactory } from './factory.js';
 
 export type PostOrganizationInvitationData = {
@@ -25,11 +25,11 @@ export class OrganizationInvitationApi extends ApiFactory<
   }
 
   override async create(json: PostOrganizationInvitationData) {
-    return authedAdminApi.post(this.path, { json }).json<OrganizationInvitationEntity>();
+    return authedApi.post(this.path, { json }).json<OrganizationInvitationEntity>();
   }
 
   async updateStatus(id: string, status: OrganizationInvitationStatus, acceptedUserId?: string) {
-    return authedAdminApi
+    return authedApi
       .put(`${this.path}/${id}/status`, {
         json: {
           status,
@@ -40,7 +40,7 @@ export class OrganizationInvitationApi extends ApiFactory<
   }
 
   async resendMessage(id: string, messagePayload: SendMessagePayload) {
-    return authedAdminApi
+    return authedApi
       .post(`${this.path}/${id}/message`, {
         json: messagePayload,
       })

--- a/packages/integration-tests/src/api/organization-jit.ts
+++ b/packages/integration-tests/src/api/organization-jit.ts
@@ -1,6 +1,6 @@
 import { type OrganizationRole, type OrganizationJitEmailDomain } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 import { RelationApiFactory } from './factory.js';
 
 export class OrganizationJitApi {
@@ -33,20 +33,20 @@ export class OrganizationJitApi {
       searchParams.append('page_size', String(pageSize));
     }
 
-    return authedAdminApi
+    return authedApi
       .get(`${this.path}/${id}/jit/email-domains`, { searchParams })
       .json<OrganizationJitEmailDomain[]>();
   }
 
   async addEmailDomain(id: string, emailDomain: string): Promise<void> {
-    await authedAdminApi.post(`${this.path}/${id}/jit/email-domains`, { json: { emailDomain } });
+    await authedApi.post(`${this.path}/${id}/jit/email-domains`, { json: { emailDomain } });
   }
 
   async deleteEmailDomain(id: string, emailDomain: string): Promise<void> {
-    await authedAdminApi.delete(`${this.path}/${id}/jit/email-domains/${emailDomain}`);
+    await authedApi.delete(`${this.path}/${id}/jit/email-domains/${emailDomain}`);
   }
 
   async replaceEmailDomains(id: string, emailDomains: string[]): Promise<void> {
-    await authedAdminApi.put(`${this.path}/${id}/jit/email-domains`, { json: { emailDomains } });
+    await authedApi.put(`${this.path}/${id}/jit/email-domains`, { json: { emailDomains } });
   }
 }

--- a/packages/integration-tests/src/api/organization-role.ts
+++ b/packages/integration-tests/src/api/organization-role.ts
@@ -6,7 +6,7 @@ import {
   type RoleType,
 } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 import { ApiFactory } from './factory.js';
 
 export type CreateOrganizationRolePostData = {
@@ -36,30 +36,30 @@ export class OrganizationRoleApi extends ApiFactory<
   }
 
   async addScopes(id: string, organizationScopeIds: string[]): Promise<void> {
-    await authedAdminApi.post(`${this.path}/${id}/scopes`, { json: { organizationScopeIds } });
+    await authedApi.post(`${this.path}/${id}/scopes`, { json: { organizationScopeIds } });
   }
 
   async getScopes(id: string, searchParams?: URLSearchParams): Promise<OrganizationScope[]> {
-    return authedAdminApi
+    return authedApi
       .get(`${this.path}/${id}/scopes`, { searchParams })
       .json<OrganizationScope[]>();
   }
 
   async deleteScope(id: string, scopeId: string): Promise<void> {
-    await authedAdminApi.delete(`${this.path}/${id}/scopes/${scopeId}`);
+    await authedApi.delete(`${this.path}/${id}/scopes/${scopeId}`);
   }
 
   async addResourceScopes(id: string, scopeIds: string[]): Promise<void> {
-    await authedAdminApi.post(`${this.path}/${id}/resource-scopes`, { json: { scopeIds } });
+    await authedApi.post(`${this.path}/${id}/resource-scopes`, { json: { scopeIds } });
   }
 
   async getResourceScopes(id: string, searchParams?: URLSearchParams): Promise<Scope[]> {
-    return authedAdminApi
+    return authedApi
       .get(`${this.path}/${id}/resource-scopes`, { searchParams })
       .json<Scope[]>();
   }
 
   async deleteResourceScope(id: string, scopeId: string): Promise<void> {
-    await authedAdminApi.delete(`${this.path}/${id}/resource-scopes/${scopeId}`);
+    await authedApi.delete(`${this.path}/${id}/resource-scopes/${scopeId}`);
   }
 }

--- a/packages/integration-tests/src/api/organization.ts
+++ b/packages/integration-tests/src/api/organization.ts
@@ -9,7 +9,7 @@ import {
   type OrganizationRole,
 } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 import { ApiFactory, RelationApiFactory } from './factory.js';
 import { OrganizationJitApi } from './organization-jit.js';
 
@@ -41,29 +41,29 @@ export class OrganizationApi extends ApiFactory<Organization, Omit<CreateOrganiz
     applicationIds: string[],
     organizationRoleIds: string[]
   ): Promise<void> {
-    await authedAdminApi.post(`${this.path}/${id}/applications/roles`, {
+    await authedApi.post(`${this.path}/${id}/applications/roles`, {
       json: { applicationIds, organizationRoleIds },
     });
   }
 
   async addUsers(id: string, userIds: string[]): Promise<void> {
-    await authedAdminApi.post(`${this.path}/${id}/users`, { json: { userIds } });
+    await authedApi.post(`${this.path}/${id}/users`, { json: { userIds } });
   }
 
   async replaceUsers(id: string, userIds: string[]): Promise<void> {
-    await authedAdminApi.put(`${this.path}/${id}/users`, { json: { userIds } });
+    await authedApi.put(`${this.path}/${id}/users`, { json: { userIds } });
   }
 
   async getUsers(
     id: string,
     query?: Query
   ): Promise<[rows: UserWithOrganizationRoles[], totalCount: number]> {
-    const got = await authedAdminApi.get(`${this.path}/${id}/users`, { searchParams: query });
+    const got = await authedApi.get(`${this.path}/${id}/users`, { searchParams: query });
     return [await got.json(), Number(got.headers.get('total-number') ?? 0)];
   }
 
   async deleteUser(id: string, userId: string): Promise<void> {
-    await authedAdminApi.delete(`${this.path}/${id}/users/${userId}`);
+    await authedApi.delete(`${this.path}/${id}/users/${userId}`);
   }
 
   async addUserRoles(
@@ -72,7 +72,7 @@ export class OrganizationApi extends ApiFactory<Organization, Omit<CreateOrganiz
     organizationRoleIds: string[],
     organizationRoleNames?: string[]
   ): Promise<void> {
-    await authedAdminApi.post(`${this.path}/${id}/users/${userId}/roles`, {
+    await authedApi.post(`${this.path}/${id}/users/${userId}/roles`, {
       json: { organizationRoleIds, organizationRoleNames },
     });
   }
@@ -83,33 +83,33 @@ export class OrganizationApi extends ApiFactory<Organization, Omit<CreateOrganiz
     organizationRoleIds: string[],
     organizationRoleNames?: string[]
   ): Promise<void> {
-    await authedAdminApi.put(`${this.path}/${id}/users/${userId}/roles`, {
+    await authedApi.put(`${this.path}/${id}/users/${userId}/roles`, {
       json: { organizationRoleIds, organizationRoleNames },
     });
   }
 
   async addUsersRoles(id: string, userIds: string[], organizationRoleIds: string[]): Promise<void> {
-    await authedAdminApi.post(`${this.path}/${id}/users/roles`, {
+    await authedApi.post(`${this.path}/${id}/users/roles`, {
       json: { userIds, organizationRoleIds },
     });
   }
 
   async getUserRoles(id: string, userId: string, query?: Query): Promise<OrganizationRole[]> {
-    return authedAdminApi
+    return authedApi
       .get(`${this.path}/${id}/users/${userId}/roles`, { searchParams: query })
       .json<OrganizationRole[]>();
   }
 
   async deleteUserRole(id: string, userId: string, roleId: string): Promise<void> {
-    await authedAdminApi.delete(`${this.path}/${id}/users/${userId}/roles/${roleId}`);
+    await authedApi.delete(`${this.path}/${id}/users/${userId}/roles/${roleId}`);
   }
 
   async getUserOrganizations(userId: string): Promise<OrganizationWithRoles[]> {
-    return authedAdminApi.get(`users/${userId}/organizations`).json<OrganizationWithRoles[]>();
+    return authedApi.get(`users/${userId}/organizations`).json<OrganizationWithRoles[]>();
   }
 
   async getUserOrganizationScopes(id: string, userId: string): Promise<OrganizationScope[]> {
-    return authedAdminApi
+    return authedApi
       .get(`${this.path}/${id}/users/${userId}/scopes`)
       .json<OrganizationScope[]>();
   }
@@ -119,7 +119,7 @@ export class OrganizationApi extends ApiFactory<Organization, Omit<CreateOrganiz
     applicationId: string,
     organizationRoleIds: string[]
   ): Promise<void> {
-    await authedAdminApi.post(`${this.path}/${id}/applications/${applicationId}/roles`, {
+    await authedApi.post(`${this.path}/${id}/applications/${applicationId}/roles`, {
       json: { organizationRoleIds },
     });
   }
@@ -140,12 +140,12 @@ export class OrganizationApi extends ApiFactory<Organization, Omit<CreateOrganiz
       search.set('page_size', String(pageSize));
     }
 
-    return authedAdminApi
+    return authedApi
       .get(`${this.path}/${id}/applications/${applicationId}/roles`, { searchParams: search })
       .json<OrganizationRole[]>();
   }
 
   async deleteApplicationRole(id: string, applicationId: string, roleId: string): Promise<void> {
-    await authedAdminApi.delete(`${this.path}/${id}/applications/${applicationId}/roles/${roleId}`);
+    await authedApi.delete(`${this.path}/${id}/applications/${applicationId}/roles/${roleId}`);
   }
 }

--- a/packages/integration-tests/src/api/resource.ts
+++ b/packages/integration-tests/src/api/resource.ts
@@ -3,10 +3,10 @@ import { type Options } from 'ky';
 
 import { generateResourceIndicator, generateResourceName } from '#src/utils.js';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const createResource = async (name?: string, indicator?: string) =>
-  authedAdminApi
+  authedApi
     .post('resources', {
       json: {
         name: name ?? generateResourceName(),
@@ -15,16 +15,16 @@ export const createResource = async (name?: string, indicator?: string) =>
     })
     .json<Resource>();
 
-export const getResources = async () => authedAdminApi.get('resources').json<Resource[]>();
+export const getResources = async () => authedApi.get('resources').json<Resource[]>();
 
 export const getResource = async (resourceId: string, options?: Options) =>
-  authedAdminApi.get(`resources/${resourceId}`, options).json<Resource>();
+  authedApi.get(`resources/${resourceId}`, options).json<Resource>();
 
 export const updateResource = async (
   resourceId: string,
   payload: Partial<Omit<CreateResource, 'id'>>
 ) =>
-  authedAdminApi
+  authedApi
     .patch(`resources/${resourceId}`, {
       json: {
         ...payload,
@@ -33,9 +33,9 @@ export const updateResource = async (
     .json<Resource>();
 
 export const deleteResource = async (resourceId: string) =>
-  authedAdminApi.delete(`resources/${resourceId}`);
+  authedApi.delete(`resources/${resourceId}`);
 
 export const setDefaultResource = async (resourceId: string, isDefault = true) =>
-  authedAdminApi
+  authedApi
     .patch(`resources/${resourceId}/is-default`, { json: { isDefault } })
     .json<Resource>();

--- a/packages/integration-tests/src/api/role.ts
+++ b/packages/integration-tests/src/api/role.ts
@@ -3,7 +3,7 @@ import { RoleType } from '@logto/schemas';
 
 import { generateRoleName } from '#src/utils.js';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export type GetRoleOptions = {
   excludeUserId?: string;
@@ -25,7 +25,7 @@ export const createRole = async ({
   isDefault?: boolean;
   scopeIds?: string[];
 }) =>
-  authedAdminApi
+  authedApi
     .post('roles', {
       json: {
         name: name ?? generateRoleName(),
@@ -38,12 +38,12 @@ export const createRole = async ({
     .json<Role>();
 
 export const getRoles = async (options?: GetRoleOptions) =>
-  authedAdminApi.get('roles', { searchParams: new URLSearchParams(options) }).json<Role[]>();
+  authedApi.get('roles', { searchParams: new URLSearchParams(options) }).json<Role[]>();
 
-export const getRole = async (roleId: string) => authedAdminApi.get(`roles/${roleId}`).json<Role>();
+export const getRole = async (roleId: string) => authedApi.get(`roles/${roleId}`).json<Role>();
 
 export const updateRole = async (roleId: string, payload: Partial<Omit<CreateRole, 'id'>>) =>
-  authedAdminApi
+  authedApi
     .patch(`roles/${roleId}`, {
       json: {
         ...payload,
@@ -51,20 +51,20 @@ export const updateRole = async (roleId: string, payload: Partial<Omit<CreateRol
     })
     .json<Role>();
 
-export const deleteRole = async (roleId: string) => authedAdminApi.delete(`roles/${roleId}`);
+export const deleteRole = async (roleId: string) => authedApi.delete(`roles/${roleId}`);
 
 export const getRoleScopes = async (roleId: string) =>
-  authedAdminApi.get(`roles/${roleId}/scopes`).json<Scope[]>();
+  authedApi.get(`roles/${roleId}/scopes`).json<Scope[]>();
 
 export const assignScopesToRole = async (scopeIds: string[], roleId: string) =>
-  authedAdminApi
+  authedApi
     .post(`roles/${roleId}/scopes`, {
       json: { scopeIds },
     })
     .json<Scope[]>();
 
 export const deleteScopeFromRole = async (scopeId: string, roleId: string) =>
-  authedAdminApi.delete(`roles/${roleId}/scopes/${scopeId}`);
+  authedApi.delete(`roles/${roleId}/scopes/${scopeId}`);
 
 /**
  * Get users assigned to the role.
@@ -75,16 +75,16 @@ export const deleteScopeFromRole = async (scopeId: string, roleId: string) =>
  */
 export const getRoleUsers = async (roleId: string, keyword?: string) => {
   const searchParams = new URLSearchParams(keyword && [['search', `%${keyword}%`]]);
-  return authedAdminApi.get(`roles/${roleId}/users`, { searchParams }).json<User[]>();
+  return authedApi.get(`roles/${roleId}/users`, { searchParams }).json<User[]>();
 };
 
 export const assignUsersToRole = async (userIds: string[], roleId: string) =>
-  authedAdminApi.post(`roles/${roleId}/users`, {
+  authedApi.post(`roles/${roleId}/users`, {
     json: { userIds },
   });
 
 export const deleteUserFromRole = async (userId: string, roleId: string) =>
-  authedAdminApi.delete(`roles/${roleId}/users/${userId}`);
+  authedApi.delete(`roles/${roleId}/users/${userId}`);
 
 /**
  * Get apps assigned to the role.
@@ -95,13 +95,13 @@ export const deleteUserFromRole = async (userId: string, roleId: string) =>
  */
 export const getRoleApplications = async (roleId: string, keyword?: string) => {
   const searchParams = new URLSearchParams(keyword && [['search', `%${keyword}%`]]);
-  return authedAdminApi.get(`roles/${roleId}/applications`, { searchParams }).json<Application[]>();
+  return authedApi.get(`roles/${roleId}/applications`, { searchParams }).json<Application[]>();
 };
 
 export const assignApplicationsToRole = async (applicationIds: string[], roleId: string) =>
-  authedAdminApi.post(`roles/${roleId}/applications`, {
+  authedApi.post(`roles/${roleId}/applications`, {
     json: { applicationIds },
   });
 
 export const deleteApplicationFromRole = async (applicationId: string, roleId: string) =>
-  authedAdminApi.delete(`roles/${roleId}/applications/${applicationId}`);
+  authedApi.delete(`roles/${roleId}/applications/${applicationId}`);

--- a/packages/integration-tests/src/api/saml-application.ts
+++ b/packages/integration-tests/src/api/saml-application.ts
@@ -5,42 +5,42 @@ import {
   type SamlApplicationSecretResponse,
 } from '@logto/schemas';
 
-import api, { authedAdminApi } from './api.js';
+import api, { authedApi } from './api.js';
 
 export const createSamlApplication = async (createSamlApplication: CreateSamlApplication) =>
-  authedAdminApi
+  authedApi
     .post('saml-applications', {
       json: createSamlApplication,
     })
     .json<SamlApplicationResponse>();
 
 export const deleteSamlApplication = async (id: string) =>
-  authedAdminApi.delete(`saml-applications/${id}`);
+  authedApi.delete(`saml-applications/${id}`);
 
 export const updateSamlApplication = async (
   id: string,
   patchSamlApplication: PatchSamlApplication
 ) =>
-  authedAdminApi
+  authedApi
     .patch(`saml-applications/${id}`, { json: patchSamlApplication })
     .json<SamlApplicationResponse>();
 
 export const getSamlApplication = async (id: string) =>
-  authedAdminApi.get(`saml-applications/${id}`).json<SamlApplicationResponse>();
+  authedApi.get(`saml-applications/${id}`).json<SamlApplicationResponse>();
 
 export const createSamlApplicationSecret = async (id: string, lifeSpanInYears: number) =>
-  authedAdminApi
+  authedApi
     .post(`saml-applications/${id}/secrets`, { json: { lifeSpanInYears } })
     .json<SamlApplicationSecretResponse>();
 
 export const getSamlApplicationSecrets = async (id: string) =>
-  authedAdminApi.get(`saml-applications/${id}/secrets`).json<SamlApplicationSecretResponse[]>();
+  authedApi.get(`saml-applications/${id}/secrets`).json<SamlApplicationSecretResponse[]>();
 
 export const deleteSamlApplicationSecret = async (id: string, secretId: string) =>
-  authedAdminApi.delete(`saml-applications/${id}/secrets/${secretId}`);
+  authedApi.delete(`saml-applications/${id}/secrets/${secretId}`);
 
 export const updateSamlApplicationSecret = async (id: string, secretId: string, active: boolean) =>
-  authedAdminApi
+  authedApi
     .patch(`saml-applications/${id}/secrets/${secretId}`, { json: { active } })
     .json<SamlApplicationSecretResponse>();
 

--- a/packages/integration-tests/src/api/scope.ts
+++ b/packages/integration-tests/src/api/scope.ts
@@ -3,15 +3,15 @@ import { type Options } from 'ky';
 
 import { generateScopeName } from '#src/utils.js';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const getScopes = async (resourceId: string, options?: Options) =>
-  authedAdminApi.get(`resources/${resourceId}/scopes`, options).json<Scope[]>();
+  authedApi.get(`resources/${resourceId}/scopes`, options).json<Scope[]>();
 
 export const createScope = async (resourceId: string, name?: string) => {
   const scopeName = name ?? generateScopeName();
 
-  return authedAdminApi
+  return authedApi
     .post(`resources/${resourceId}/scopes`, {
       json: {
         name: scopeName,
@@ -26,7 +26,7 @@ export const updateScope = async (
   scopeId: string,
   payload: Partial<Omit<CreateScope, 'id' | 'resourceId'>>
 ) =>
-  authedAdminApi
+  authedApi
     .patch(`resources/${resourceId}/scopes/${scopeId}`, {
       json: {
         ...payload,
@@ -35,4 +35,4 @@ export const updateScope = async (
     .json<Scope>();
 
 export const deleteScope = async (resourceId: string, scopeId: string) =>
-  authedAdminApi.delete(`resources/${resourceId}/scopes/${scopeId}`);
+  authedApi.delete(`resources/${resourceId}/scopes/${scopeId}`);

--- a/packages/integration-tests/src/api/sign-in-experience.ts
+++ b/packages/integration-tests/src/api/sign-in-experience.ts
@@ -1,14 +1,14 @@
 import type { SignInExperience } from '@logto/schemas';
 import { type KyInstance } from 'ky';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
-export const getSignInExperience = async (api: KyInstance = authedAdminApi) =>
+export const getSignInExperience = async (api: KyInstance = authedApi) =>
   api.get('sign-in-exp').json<SignInExperience>();
 
 export const updateSignInExperience = async (
   signInExperience: Partial<SignInExperience>,
-  api: KyInstance = authedAdminApi
+  api: KyInstance = authedApi
 ) =>
   api
     .patch('sign-in-exp', {

--- a/packages/integration-tests/src/api/sso-connector.ts
+++ b/packages/integration-tests/src/api/sso-connector.ts
@@ -8,7 +8,7 @@ import {
 } from '@logto/schemas';
 
 import { metadataXml } from '#src/__mocks__/sso-connectors-mock.js';
-import { authedAdminApi } from '#src/api/api.js';
+import { authedApi } from '#src/api/api.js';
 import { logtoUrl } from '#src/constants.js';
 import { randomString } from '#src/utils.js';
 
@@ -19,26 +19,26 @@ export type SsoConnectorWithProviderConfig = SsoConnector & {
 };
 
 export const getSsoConnectorFactories = async () =>
-  authedAdminApi.get('sso-connector-providers').json<SsoConnectorProvidersResponse>();
+  authedApi.get('sso-connector-providers').json<SsoConnectorProvidersResponse>();
 
 export const createSsoConnector = async (data: Partial<CreateSsoConnector>) =>
-  authedAdminApi
+  authedApi
     .post('sso-connectors', {
       json: data,
     })
     .json<SsoConnector>();
 
 export const getSsoConnectors = async () =>
-  authedAdminApi.get('sso-connectors').json<SsoConnectorWithProviderConfig[]>();
+  authedApi.get('sso-connectors').json<SsoConnectorWithProviderConfig[]>();
 
 export const getSsoConnectorById = async (id: string) =>
-  authedAdminApi.get(`sso-connectors/${id}`).json<SsoConnectorWithProviderConfig>();
+  authedApi.get(`sso-connectors/${id}`).json<SsoConnectorWithProviderConfig>();
 
 export const deleteSsoConnectorById = async (id: string) =>
-  authedAdminApi.delete(`sso-connectors/${id}`).json<void>();
+  authedApi.delete(`sso-connectors/${id}`).json<void>();
 
 export const patchSsoConnectorById = async (id: string, data: Partial<SsoConnector>) =>
-  authedAdminApi
+  authedApi
     .patch(`sso-connectors/${id}`, {
       json: data,
     })
@@ -106,7 +106,7 @@ export class SsoConnectorApi {
 
   async setSsoConnectorIdpInitiatedAuthConfig(data: CreateSsoConnectorIdpInitiatedAuthConfig) {
     const { connectorId, ...rest } = data;
-    return authedAdminApi
+    return authedApi
       .put(`sso-connectors/${connectorId}/idp-initiated-auth-config`, {
         json: rest,
       })
@@ -114,13 +114,13 @@ export class SsoConnectorApi {
   }
 
   async getSsoConnectorIdpInitiatedAuthConfig(connectorId: string) {
-    return authedAdminApi
+    return authedApi
       .get(`sso-connectors/${connectorId}/idp-initiated-auth-config`)
       .json<SsoConnectorIdpInitiatedAuthConfig>();
   }
 
   async deleteSsoConnectorIdpInitiatedAuthConfig(connectorId: string) {
-    return authedAdminApi
+    return authedApi
       .delete(`sso-connectors/${connectorId}/idp-initiated-auth-config`)
       .json<void>();
   }

--- a/packages/integration-tests/src/api/subject-token.ts
+++ b/packages/integration-tests/src/api/subject-token.ts
@@ -1,9 +1,9 @@
 import type { JsonObject, SubjectTokenResponse } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const createSubjectToken = async (userId: string, context?: JsonObject) =>
-  authedAdminApi
+  authedApi
     .post('subject-tokens', {
       json: {
         userId,

--- a/packages/integration-tests/src/api/verification-code.ts
+++ b/packages/integration-tests/src/api/verification-code.ts
@@ -1,9 +1,9 @@
 import type { VerifyVerificationCodePayload } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import { authedApi } from './api.js';
 
 export const requestVerificationCode = async (payload: unknown) =>
-  authedAdminApi.post('verification-codes', { json: payload });
+  authedApi.post('verification-codes', { json: payload });
 
 export const verifyVerificationCode = async (payload: VerifyVerificationCodePayload) =>
-  authedAdminApi.post('verification-codes/verify', { json: payload });
+  authedApi.post('verification-codes/verify', { json: payload });

--- a/packages/integration-tests/src/client/experience/index.ts
+++ b/packages/integration-tests/src/client/experience/index.ts
@@ -21,7 +21,7 @@ type RedirectResponse = {
 export class ExperienceClient extends MockClient {
   public async identifyUser(payload: IdentificationApiPayload = {}) {
     return this.api.post(experienceRoutes.identification, {
-      headers: { cookie: this.interactionCookie },
+      headers: { cookie: this.sessionCookie },
       json: payload,
     });
   }
@@ -29,7 +29,7 @@ export class ExperienceClient extends MockClient {
   public async updateInteractionEvent(payload: { interactionEvent: InteractionEvent }) {
     return this.api
       .put(`${experienceRoutes.prefix}/interaction-event`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json();
@@ -38,7 +38,7 @@ export class ExperienceClient extends MockClient {
   public async initInteraction(payload: CreateExperienceApiPayload) {
     return this.api
       .put(experienceRoutes.prefix, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json();
@@ -46,14 +46,14 @@ export class ExperienceClient extends MockClient {
 
   public override async submitInteraction(): Promise<RedirectResponse> {
     return this.api
-      .post(`${experienceRoutes.prefix}/submit`, { headers: { cookie: this.interactionCookie } })
+      .post(`${experienceRoutes.prefix}/submit`, { headers: { cookie: this.sessionCookie } })
       .json<RedirectResponse>();
   }
 
   public async verifyPassword(payload: PasswordVerificationPayload) {
     return this.api
       .post(`${experienceRoutes.verification}/password`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ verificationId: string }>();
@@ -65,7 +65,7 @@ export class ExperienceClient extends MockClient {
   }) {
     return this.api
       .post(`${experienceRoutes.verification}/verification-code`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ verificationId: string }>();
@@ -78,7 +78,7 @@ export class ExperienceClient extends MockClient {
   }) {
     return this.api
       .post(`${experienceRoutes.verification}/verification-code/verify`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ verificationId: string }>();
@@ -93,7 +93,7 @@ export class ExperienceClient extends MockClient {
   ) {
     return this.api
       .post(`${experienceRoutes.verification}/social/${connectorId}/authorization-uri`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ authorizationUri: string; verificationId: string }>();
@@ -108,7 +108,7 @@ export class ExperienceClient extends MockClient {
   ) {
     return this.api
       .post(`${experienceRoutes.verification}/social/${connectorId}/verify`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ verificationId: string }>();
@@ -123,7 +123,7 @@ export class ExperienceClient extends MockClient {
   ) {
     return this.api
       .post(`${experienceRoutes.verification}/sso/${connectorId}/authorization-uri`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ authorizationUri: string; verificationId: string }>();
@@ -138,7 +138,7 @@ export class ExperienceClient extends MockClient {
   ) {
     return this.api
       .post(`${experienceRoutes.verification}/sso/${connectorId}/verify`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ verificationId: string }>();
@@ -147,7 +147,7 @@ export class ExperienceClient extends MockClient {
   public async getAvailableSsoConnectors(email: string) {
     return this.api
       .get(`${experienceRoutes.prefix}/sso-connectors`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         searchParams: { email },
       })
       .json<{ connectorIds: string[] }>();
@@ -156,7 +156,7 @@ export class ExperienceClient extends MockClient {
   public async createTotpSecret() {
     return this.api
       .post(`${experienceRoutes.verification}/totp/secret`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
       })
       .json<{ verificationId: string; secret: string; secretQrCode: string }>();
   }
@@ -164,7 +164,7 @@ export class ExperienceClient extends MockClient {
   public async verifyTotp(payload: { verificationId?: string; code: string }) {
     return this.api
       .post(`${experienceRoutes.verification}/totp/verify`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ verificationId: string }>();
@@ -173,7 +173,7 @@ export class ExperienceClient extends MockClient {
   public async generateMfaBackupCodes() {
     return this.api
       .post(`${experienceRoutes.verification}/backup-code/generate`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
       })
       .json<{ verificationId: string; codes: string[] }>();
   }
@@ -181,7 +181,7 @@ export class ExperienceClient extends MockClient {
   public async verifyBackupCode(payload: { code: string }) {
     return this.api
       .post(`${experienceRoutes.verification}/backup-code/verify`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ verificationId: string }>();
@@ -192,7 +192,7 @@ export class ExperienceClient extends MockClient {
   ) {
     return this.api
       .post(`${experienceRoutes.verification}/new-password-identity`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ verificationId: string }>();
@@ -200,27 +200,27 @@ export class ExperienceClient extends MockClient {
 
   public async resetPassword(payload: { password: string }) {
     return this.api.put(`${experienceRoutes.profile}/password`, {
-      headers: { cookie: this.interactionCookie },
+      headers: { cookie: this.sessionCookie },
       json: payload,
     });
   }
 
   public async updateProfile(payload: UpdateProfileApiPayload) {
     return this.api.post(`${experienceRoutes.profile}`, {
-      headers: { cookie: this.interactionCookie },
+      headers: { cookie: this.sessionCookie },
       json: payload,
     });
   }
 
   public async skipMfaBinding() {
     return this.api.post(`${experienceRoutes.mfa}/mfa-skipped`, {
-      headers: { cookie: this.interactionCookie },
+      headers: { cookie: this.sessionCookie },
     });
   }
 
   public async bindMfa(type: MfaFactor, verificationId: string) {
     return this.api.post(`${experienceRoutes.mfa}`, {
-      headers: { cookie: this.interactionCookie },
+      headers: { cookie: this.sessionCookie },
       json: { type, verificationId },
     });
   }
@@ -231,7 +231,7 @@ export class ExperienceClient extends MockClient {
   }) {
     return this.api
       .post(`${experienceRoutes.verification}/one-time-token/verify`, {
-        headers: { cookie: this.interactionCookie },
+        headers: { cookie: this.sessionCookie },
         json: payload,
       })
       .json<{ verificationId: string }>();

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -37,8 +37,7 @@ export default class MockClient {
     });
   }
 
-  // TODO: Rename to sessionCookies or something accurate
-  public get interactionCookie(): string {
+  public get sessionCookie(): string {
     return this.rawCookies.join('; ');
   }
 
@@ -87,7 +86,7 @@ export default class MockClient {
 
     // Get session cookie
     this.rawCookies = response.headers.getSetCookie();
-    assert(this.interactionCookie, new Error('Get cookie from authorization endpoint failed'));
+    assert(this.sessionCookie, new Error('Get cookie from authorization endpoint failed'));
   }
 
   /**
@@ -104,7 +103,7 @@ export default class MockClient {
 
     const authResponse = await ky.get(redirectTo, {
       headers: {
-        cookie: this.interactionCookie,
+        cookie: this.sessionCookie,
       },
       redirect: 'manual',
       throwHttpErrors: false,
@@ -130,7 +129,7 @@ export default class MockClient {
   public async manualConsent(redirectTo: string) {
     const authCodeResponse = await ky.get(redirectTo, {
       headers: {
-        cookie: this.interactionCookie,
+        cookie: this.sessionCookie,
       },
       redirect: 'manual',
       throwHttpErrors: false,
@@ -190,28 +189,28 @@ export default class MockClient {
     api: (cookie: string, ...args: Args) => Promise<T>,
     ...payload: Args
   ) {
-    return api(this.interactionCookie, ...payload);
+    return api(this.sessionCookie, ...payload);
   }
 
   public async successSend<Args extends unknown[], T>(
     api: (cookie: string, ...args: Args) => Promise<T>,
     ...payload: Args
   ) {
-    return expect(api(this.interactionCookie, ...payload)).resolves.not.toThrow();
+    return expect(api(this.sessionCookie, ...payload)).resolves.not.toThrow();
   }
 
   public async submitInteraction() {
-    return submitInteraction(this.api, this.interactionCookie);
+    return submitInteraction(this.api, this.sessionCookie);
   }
 
   private readonly consent = async () => {
     // Note: If sign in action completed successfully, we will get `_session.sig` in the cookie.
-    assert(this.interactionCookie, new Error('Session not found'));
-    assert(this.interactionCookie.includes('_session.sig'), new Error('Session not found'));
+    assert(this.sessionCookie, new Error('Session not found'));
+    assert(this.sessionCookie.includes('_session.sig'), new Error('Session not found'));
 
     const consentResponse = await ky.get(`${this.config.endpoint}/consent`, {
       headers: {
-        cookie: this.interactionCookie,
+        cookie: this.sessionCookie,
       },
       redirect: 'manual',
       throwHttpErrors: false,
@@ -226,7 +225,7 @@ export default class MockClient {
 
     const authCodeResponse = await ky.get(redirectTo, {
       headers: {
-        cookie: this.interactionCookie,
+        cookie: this.sessionCookie,
       },
       redirect: 'manual',
       throwHttpErrors: false,

--- a/packages/integration-tests/src/helpers/client.ts
+++ b/packages/integration-tests/src/helpers/client.ts
@@ -13,7 +13,7 @@ export const initClient = async (
 ) => {
   const client = new MockClient(config);
   await client.initSession(redirectUri, options);
-  assert(client.interactionCookie, new Error('Session not found'));
+  assert(client.sessionCookie, new Error('Session not found'));
 
   return client;
 };
@@ -35,7 +35,7 @@ export const initExperienceClient = async ({
 } = {}) => {
   const client = new ExperienceClient(config, api);
   await client.initSession(redirectUri, options);
-  assert(client.interactionCookie, new Error('Session not found'));
+  assert(client.sessionCookie, new Error('Session not found'));
   await client.initInteraction({ interactionEvent, captchaToken });
 
   return client;

--- a/packages/integration-tests/src/helpers/hook.ts
+++ b/packages/integration-tests/src/helpers/hook.ts
@@ -1,6 +1,6 @@
 import { type CreateHook, type Hook, type HookConfig, type HookEvent } from '@logto/schemas';
 
-import { authedAdminApi } from '#src/api/api.js';
+import { authedApi } from '#src/api/api.js';
 
 type HookCreationPayload = Pick<Hook, 'name' | 'events'> & {
   config: HookConfig;
@@ -26,7 +26,7 @@ export class WebHookApiTest {
   }
 
   async create(json: Omit<CreateHook, 'id'>): Promise<Hook> {
-    const hook = await authedAdminApi.post('hooks', { json }).json<Hook>();
+    const hook = await authedApi.post('hooks', { json }).json<Hook>();
     this.#hooks.set(hook.name, hook);
 
     return hook;
@@ -36,7 +36,7 @@ export class WebHookApiTest {
     const hook = this.#hooks.get(name);
 
     if (hook) {
-      await authedAdminApi.delete(`hooks/${hook.id}`);
+      await authedApi.delete(`hooks/${hook.id}`);
       this.#hooks.delete(name);
     }
   }

--- a/packages/integration-tests/src/helpers/profile.ts
+++ b/packages/integration-tests/src/helpers/profile.ts
@@ -6,7 +6,7 @@ import { type InteractionPayload } from '#src/api/interaction.js';
 import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
 import { generatePassword, generateUsername } from '#src/utils.js';
 
-import api, { baseApi, authedAdminApi } from '../api/api.js';
+import api, { baseApi, authedApi } from '../api/api.js';
 
 import { initClient } from './client.js';
 
@@ -19,7 +19,7 @@ export const createDefaultTenantUserWithPassword = async ({
 } = {}) => {
   const username = generateUsername();
   const password = generatePassword();
-  const user = await authedAdminApi
+  const user = await authedApi
     .post('users', {
       json: { username, password, primaryEmail, primaryPhone },
     })
@@ -29,7 +29,7 @@ export const createDefaultTenantUserWithPassword = async ({
 };
 
 export const deleteDefaultTenantUser = async (id: string) => {
-  await authedAdminApi.delete(`users/${id}`);
+  await authedApi.delete(`users/${id}`);
 };
 
 export const putInteraction = async (cookie: string, payload: InteractionPayload) =>

--- a/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
@@ -4,7 +4,7 @@ import { SignInIdentifier } from '@logto/schemas';
 import { PhoneNumberParser } from '@logto/shared';
 
 import { enableAllAccountCenterFields } from '#src/api/account-center.js';
-import { authedAdminApi } from '#src/api/api.js';
+import { authedApi } from '#src/api/api.js';
 import {
   deletePrimaryEmail,
   deletePrimaryPhone,
@@ -30,9 +30,9 @@ import { generateEmail, generatePhone, generateNationalPhoneNumber } from '#src/
 describe('account (email and phone)', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
-    await setEmailConnector(authedAdminApi);
-    await setSmsConnector(authedAdminApi);
-    await enableAllAccountCenterFields(authedAdminApi);
+    await setEmailConnector(authedApi);
+    await setSmsConnector(authedApi);
+    await enableAllAccountCenterFields(authedApi);
   });
 
   describe('POST /my-account/primary-email', () => {

--- a/packages/integration-tests/src/tests/api/admin-user.search.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.search.test.ts
@@ -1,6 +1,6 @@
 import type { Role, User } from '@logto/schemas';
 
-import { assignRolesToUser, authedAdminApi, createUser, deleteUser } from '#src/api/index.js';
+import { assignRolesToUser, authedApi, createUser, deleteUser } from '#src/api/index.js';
 import { createRole, deleteRole } from '#src/api/role.js';
 import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
 import { OrganizationApiTest } from '#src/helpers/organization.js';
@@ -9,7 +9,7 @@ import { UserApiTest } from '#src/helpers/user.js';
 const getUsers = async <T>(
   init: string[][] | Record<string, string> | URLSearchParams
 ): Promise<{ headers: Headers; json: T }> => {
-  const response = await authedAdminApi.get('users', {
+  const response = await authedApi.get('users', {
     searchParams: new URLSearchParams(init),
   });
 

--- a/packages/integration-tests/src/tests/api/admin-user.username-case.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.username-case.test.ts
@@ -1,13 +1,13 @@
 import { type User } from '@logto/schemas';
 
-import { authedAdminApi, deleteUser } from '#src/api/index.js';
+import { authedApi, deleteUser } from '#src/api/index.js';
 import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
 import { generateUsername } from '#src/utils.js';
 
 const getUsers = async <T>(
   init: string[][] | Record<string, string> | URLSearchParams
 ): Promise<{ headers: Headers; json: T }> => {
-  const response = await authedAdminApi.get('users', {
+  const response = await authedApi.get('users', {
     searchParams: new URLSearchParams(init),
   });
 

--- a/packages/integration-tests/src/tests/api/application/application.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application.test.ts
@@ -8,6 +8,7 @@ import {
   getApplications,
   updateApplication,
 } from '#src/api/index.js';
+import { createSamlApplication, deleteSamlApplication } from '#src/api/saml-application.js';
 import { expectRejects } from '#src/helpers/index.js';
 
 describe('application APIs', () => {
@@ -42,7 +43,17 @@ describe('application APIs', () => {
     });
   });
 
-  // TODO: add tests for blocking updating SAML application with `PATCH /applications/:id` API, we can not do it before we implement the `POST /saml-applications` API
+
+  it('should not update SAML application with applications API', async () => {
+    const { id } = await createSamlApplication({ name: 'test-saml', description: 'test' });
+
+    await expectRejects(updateApplication(id, { description: 'new' }), {
+      code: 'application.saml.use_saml_app_api',
+      status: 400,
+    });
+
+    await deleteSamlApplication(id);
+  });
 
   it('should create OIDC third party application successfully', async () => {
     const applicationName = 'test-third-party-app';

--- a/packages/integration-tests/src/tests/api/experience-api/basic-sentinel.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/basic-sentinel.test.ts
@@ -1,6 +1,6 @@
 import { SignInIdentifier } from '@logto/schemas';
 
-import { authedAdminApi } from '#src/api/api.js';
+import { authedApi } from '#src/api/api.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { initExperienceClient } from '#src/helpers/client.js';
 import { signInWithPassword } from '#src/helpers/experience/index.js';
@@ -67,7 +67,7 @@ describe('basic sentinel', () => {
     });
 
     it('should unblock the identifier by calling management API', async () => {
-      await authedAdminApi.post('sentinel-activities/delete', {
+      await authedApi.post('sentinel-activities/delete', {
         json: {
           targetType: 'User',
           targets: [fakeUsername],
@@ -162,7 +162,7 @@ describe('basic sentinel', () => {
     });
 
     it('should unblock the identifier by calling management API', async () => {
-      await authedAdminApi.post('sentinel-activities/delete', {
+      await authedApi.post('sentinel-activities/delete', {
         json: {
           targetType: 'User',
           targets: [username],

--- a/packages/integration-tests/src/tests/api/hook/hook.stats.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.stats.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@logto/schemas';
 
 import { deleteUser } from '#src/api/admin-user.js';
-import { authedAdminApi } from '#src/api/api.js';
+import { authedApi } from '#src/api/api.js';
 import { getHookCreationPayload } from '#src/helpers/hook.js';
 import { createMockServer } from '#src/helpers/index.js';
 import { registerNewUser } from '#src/helpers/interactions.js';
@@ -32,7 +32,7 @@ describe('hook logs', () => {
   });
 
   it('should get recent hook logs correctly', async () => {
-    const createdHook = await authedAdminApi
+    const createdHook = await authedApi
       .post('hooks', {
         json: getHookCreationPayload(InteractionHookEvent.PostRegister, 'http://localhost:9999'),
       })
@@ -41,7 +41,7 @@ describe('hook logs', () => {
     const { username, password } = generateNewUserProfile({ username: true, password: true });
     const userId = await registerNewUser(username, password);
 
-    const logs = await authedAdminApi
+    const logs = await authedApi
       .get(`hooks/${createdHook.id}/recent-logs?page_size=100`)
       .json<Log[]>();
     expect(
@@ -51,19 +51,19 @@ describe('hook logs', () => {
       )
     ).toBeTruthy();
 
-    await authedAdminApi.delete(`hooks/${createdHook.id}`);
+    await authedApi.delete(`hooks/${createdHook.id}`);
 
     await deleteUser(userId);
   });
 
   it('should get hook execution stats correctly', async () => {
-    const createdHook = await authedAdminApi
+    const createdHook = await authedApi
       .post('hooks', {
         json: getHookCreationPayload(InteractionHookEvent.PostRegister, 'http://localhost:9999'),
       })
       .json<Hook>();
 
-    const hooksWithExecutionStats = await authedAdminApi
+    const hooksWithExecutionStats = await authedApi
       .get('hooks?includeExecutionStats=true')
       .json<HookResponse[]>();
 
@@ -74,7 +74,7 @@ describe('hook logs', () => {
     const { username, password } = generateNewUserProfile({ username: true, password: true });
     const userId = await registerNewUser(username, password);
 
-    const hookWithExecutionStats = await authedAdminApi
+    const hookWithExecutionStats = await authedApi
       .get(`hooks/${createdHook.id}?includeExecutionStats=true`)
       .json<HookResponse>();
 
@@ -84,7 +84,7 @@ describe('hook logs', () => {
     expect(executionStats.requestCount).toBe(1);
     expect(executionStats.successCount).toBe(1);
 
-    await authedAdminApi.delete(`hooks/${createdHook.id}`);
+    await authedApi.delete(`hooks/${createdHook.id}`);
 
     await deleteUser(userId);
   });

--- a/packages/integration-tests/src/tests/api/hook/hook.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.test.ts
@@ -1,26 +1,26 @@
 import type { Hook } from '@logto/schemas';
 import { InteractionHookEvent } from '@logto/schemas';
 
-import { authedAdminApi } from '#src/api/index.js';
+import { authedApi } from '#src/api/index.js';
 import { getHookCreationPayload } from '#src/helpers/hook.js';
 import { expectRejects } from '#src/helpers/index.js';
 
 describe('hooks', () => {
   it('should be able to create, query, update, and delete a hook', async () => {
     const payload = getHookCreationPayload(InteractionHookEvent.PostRegister);
-    const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
+    const created = await authedApi.post('hooks', { json: payload }).json<Hook>();
 
     expect(created).toMatchObject(payload);
 
-    expect(await authedAdminApi.get('hooks').json<Hook[]>()).toContainEqual(created);
-    expect(await authedAdminApi.get(`hooks/${created.id}`).json<Hook>()).toEqual(created);
+    expect(await authedApi.get('hooks').json<Hook[]>()).toContainEqual(created);
+    expect(await authedApi.get(`hooks/${created.id}`).json<Hook>()).toEqual(created);
     expect(
-      await authedAdminApi
+      await authedApi
         .patch(`hooks/${created.id}`, { json: { events: [InteractionHookEvent.PostSignIn] } })
         .json<Hook>()
     ).toMatchObject({ ...created, events: [InteractionHookEvent.PostSignIn] });
-    expect(await authedAdminApi.delete(`hooks/${created.id}`)).toHaveProperty('status', 204);
-    await expectRejects(authedAdminApi.get(`hooks/${created.id}`), {
+    expect(await authedApi.delete(`hooks/${created.id}`)).toHaveProperty('status', 204);
+    await expectRejects(authedApi.get(`hooks/${created.id}`), {
       code: 'entity.not_exists_with_id',
       status: 404,
     });
@@ -34,22 +34,22 @@ describe('hooks', () => {
         retries: 2,
       },
     };
-    const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
+    const created = await authedApi.post('hooks', { json: payload }).json<Hook>();
 
     expect(created).toMatchObject(payload);
 
-    expect(await authedAdminApi.get('hooks').json<Hook[]>()).toContainEqual(created);
-    expect(await authedAdminApi.get(`hooks/${created.id}`).json<Hook>()).toEqual(created);
+    expect(await authedApi.get('hooks').json<Hook[]>()).toContainEqual(created);
+    expect(await authedApi.get(`hooks/${created.id}`).json<Hook>()).toEqual(created);
     expect(
-      await authedAdminApi
+      await authedApi
         .patch(`hooks/${created.id}`, { json: { event: InteractionHookEvent.PostSignIn } })
         .json<Hook>()
     ).toMatchObject({
       ...created,
       event: InteractionHookEvent.PostSignIn,
     });
-    expect(await authedAdminApi.delete(`hooks/${created.id}`)).toHaveProperty('status', 204);
-    await expectRejects(authedAdminApi.get(`hooks/${created.id}`), {
+    expect(await authedApi.delete(`hooks/${created.id}`)).toHaveProperty('status', 204);
+    await expectRejects(authedApi.get(`hooks/${created.id}`), {
       code: 'entity.not_exists_with_id',
       status: 404,
     });
@@ -57,15 +57,15 @@ describe('hooks', () => {
 
   it('should return hooks with pagination if pagination-related query params are provided', async () => {
     const payload = getHookCreationPayload(InteractionHookEvent.PostRegister);
-    const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
+    const created = await authedApi.post('hooks', { json: payload }).json<Hook>();
 
-    const response = await authedAdminApi.get('hooks?page=1&page_size=20');
+    const response = await authedApi.get('hooks?page=1&page_size=20');
 
     expect(response.status).toBe(200);
     expect(response.headers.get('total-number')).toEqual(expect.any(String));
 
     // Clean up
-    await authedAdminApi.delete(`hooks/${created.id}`);
+    await authedApi.delete(`hooks/${created.id}`);
   });
 
   it('should throw error when creating a hook with an empty hook name', async () => {
@@ -76,7 +76,7 @@ describe('hooks', () => {
         url: 'not_work_url',
       },
     };
-    await expectRejects(authedAdminApi.post('hooks', { json: payload }), {
+    await expectRejects(authedApi.post('hooks', { json: payload }), {
       code: 'guard.invalid_input',
       status: 400,
     });
@@ -89,7 +89,7 @@ describe('hooks', () => {
         url: 'not_work_url',
       },
     };
-    await expectRejects(authedAdminApi.post('hooks', { json: payload }), {
+    await expectRejects(authedApi.post('hooks', { json: payload }), {
       code: 'hook.missing_events',
       status: 400,
     });
@@ -100,14 +100,14 @@ describe('hooks', () => {
       name: 'new_hook_name',
     };
 
-    await expectRejects(authedAdminApi.patch('hooks/invalid_id', { json: payload }), {
+    await expectRejects(authedApi.patch('hooks/invalid_id', { json: payload }), {
       code: 'entity.not_exists',
       status: 404,
     });
   });
 
   it('should throw error if regenerate a hook signing key with a invalid hook id', async () => {
-    await expectRejects(authedAdminApi.patch('hooks/invalid_id/signing-key'), {
+    await expectRejects(authedApi.patch('hooks/invalid_id/signing-key'), {
       code: 'entity.not_exists',
       status: 404,
     });

--- a/packages/integration-tests/src/tests/api/hook/hook.testing.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.testing.test.ts
@@ -1,6 +1,6 @@
 import { InteractionHookEvent, type Hook } from '@logto/schemas';
 
-import { authedAdminApi } from '#src/api/api.js';
+import { authedApi } from '#src/api/api.js';
 import { getHookCreationPayload } from '#src/helpers/hook.js';
 import { createMockServer, expectRejects } from '#src/helpers/index.js';
 
@@ -36,20 +36,20 @@ describe('hook testing', () => {
       InteractionHookEvent.PostRegister,
       responseSuccessEndpoint
     );
-    const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
-    const response = await authedAdminApi.post(`hooks/${created.id}/test`, {
+    const created = await authedApi.post('hooks', { json: payload }).json<Hook>();
+    const response = await authedApi.post(`hooks/${created.id}/test`, {
       json: { events: [InteractionHookEvent.PostSignIn], config: { url: responseSuccessEndpoint } },
     });
     expect(response.status).toBe(204);
 
     // Clean Up
-    await authedAdminApi.delete(`hooks/${created.id}`);
+    await authedApi.delete(`hooks/${created.id}`);
   });
 
   it('should return 404 if the hook to test does not exist', async () => {
     const invalidHookId = 'invalid_id';
     await expectRejects(
-      authedAdminApi.post(`hooks/${invalidHookId}/test`, {
+      authedApi.post(`hooks/${invalidHookId}/test`, {
         json: {
           events: [InteractionHookEvent.PostSignIn],
           config: { url: responseSuccessEndpoint },
@@ -64,9 +64,9 @@ describe('hook testing', () => {
 
   it('should return 422 if the hook endpoint is not working', async () => {
     const payload = getHookCreationPayload(InteractionHookEvent.PostRegister);
-    const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
+    const created = await authedApi.post('hooks', { json: payload }).json<Hook>();
     await expectRejects(
-      authedAdminApi.post(`hooks/${created.id}/test`, {
+      authedApi.post(`hooks/${created.id}/test`, {
         json: { events: [InteractionHookEvent.PostSignIn], config: { url: 'not_work_url' } },
       }),
       {
@@ -76,14 +76,14 @@ describe('hook testing', () => {
     );
 
     // Clean Up
-    await authedAdminApi.delete(`hooks/${created.id}`);
+    await authedApi.delete(`hooks/${created.id}`);
   });
 
   it('should return 422 and contains endpoint response if the hook endpoint return 500', async () => {
     const payload = getHookCreationPayload(InteractionHookEvent.PostRegister);
-    const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
+    const created = await authedApi.post('hooks', { json: payload }).json<Hook>();
     await expectRejects(
-      authedAdminApi.post(`hooks/${created.id}/test`, {
+      authedApi.post(`hooks/${created.id}/test`, {
         json: { events: [InteractionHookEvent.PostSignIn], config: { url: responseErrorEndpoint } },
       }),
       {
@@ -93,6 +93,6 @@ describe('hook testing', () => {
     );
 
     // Clean Up
-    await authedAdminApi.delete(`hooks/${created.id}`);
+    await authedApi.delete(`hooks/${created.id}`);
   });
 });

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.custom.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.custom.data.test.ts
@@ -173,6 +173,25 @@ describe('manual data hook tests', () => {
 
       await assertOrganizationMembershipUpdated(organization.id);
     });
+
+    it('should trigger `Organization.Membership.Updated` event when user is removed from organization', async () => {
+      await setEmailConnector();
+      await setSmsConnector();
+      await enableAllVerificationCodeSignInMethods({
+        identifiers: [SignInIdentifier.Email],
+        password: false,
+        verify: true,
+      });
+
+      const organization = await organizationApi.create({ name: 'baz' });
+      const domain = 'delete.com';
+      await organizationApi.jit.addEmailDomain(organization.id, domain);
+
+      const { id: userId } = await registerWithEmail(`${randomString()}@${domain}`);
+      await organizationApi.deleteUser(organization.id, userId);
+
+      await assertOrganizationMembershipUpdated(organization.id);
+    });
   });
 
   describe('organization membership update by accept organization invitation', () => {

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
@@ -10,7 +10,7 @@ import {
 import { assert } from '@silverhand/essentials';
 import { z } from 'zod';
 
-import { authedAdminApi } from '#src/api/api.js';
+import { authedApi } from '#src/api/api.js';
 import { createApplication, deleteApplication } from '#src/api/application.js';
 import { createResource } from '#src/api/resource.js';
 import { createScope } from '#src/api/scope.js';
@@ -119,7 +119,7 @@ describe('user data hook events', () => {
   it.each(userDataHookTestCases)(
     'test case %#: %p',
     async ({ route, event, method, endpoint, payload }) => {
-      await authedAdminApi[method](endpoint.replace('{userId}', userId), { json: payload });
+      await authedApi[method](endpoint.replace('{userId}', userId), { json: payload });
       const hook = await getWebhookResult(route);
       expect(hook?.payload.event).toBe(event);
     }
@@ -127,7 +127,7 @@ describe('user data hook events', () => {
 
   // Clean up
   afterAll(async () => {
-    await authedAdminApi.delete(`users/${userId}`);
+    await authedApi.delete(`users/${userId}`);
   });
 });
 
@@ -140,7 +140,7 @@ describe('role data hook events', () => {
 
   beforeAll(async () => {
     // Create a role to trigger the Role.Created event.
-    const role = await authedAdminApi
+    const role = await authedApi
       .post('roles', {
         json: { name: generateName(), description: 'data-hook-role', type: RoleType.User },
       })
@@ -161,13 +161,13 @@ describe('role data hook events', () => {
   });
 
   afterAll(async () => {
-    await authedAdminApi.delete(`resources/${resourceId}`);
+    await authedApi.delete(`resources/${resourceId}`);
   });
 
   it.each(roleDataHookTestCases)(
     'test case %#: %p',
     async ({ route, event, method, endpoint, payload }) => {
-      await authedAdminApi[method](
+      await authedApi[method](
         endpoint.replace('{roleId}', roleId).replace('{scopeId}', scopeId),
         // Replace all the scopeId placeholder in the payload
         { json: JSON.parse(JSON.stringify(payload).replace('{scopeId}', scopeId)) }
@@ -198,13 +198,13 @@ describe('scope data hook events', () => {
   });
 
   afterAll(async () => {
-    await authedAdminApi.delete(`resources/${resourceId}`);
+    await authedApi.delete(`resources/${resourceId}`);
   });
 
   it.each(scopesDataHookTestCases)(
     'test case %#: %p',
     async ({ route, event, method, endpoint, payload }) => {
-      await authedAdminApi[method](
+      await authedApi[method](
         endpoint.replace('{resourceId}', resourceId).replace('{scopeId}', scopeId),
         { json: payload }
       );
@@ -251,12 +251,9 @@ describe('organization data hook events', () => {
   it.each(organizationDataHookTestCases)(
     'test case %#: %p',
     async ({ route, event, method, endpoint, payload, hookPayload }) => {
-      // TODO: Remove this check
-      if (route.includes('applications') && !isDevFeaturesEnabled) {
-        return;
-      }
 
-      await authedAdminApi[method](
+
+      await authedApi[method](
         endpoint
           .replace('{organizationId}', organizationId)
           .replace('{userId}', userId)
@@ -306,7 +303,7 @@ describe('organization scope data hook events', () => {
   it.each(organizationScopeDataHookTestCases)(
     'test case %#: %p',
     async ({ route, event, method, endpoint, payload }) => {
-      await authedAdminApi[method](endpoint.replace('{organizationScopeId}', scopeId), {
+      await authedApi[method](endpoint.replace('{organizationScopeId}', scopeId), {
         json: payload,
       });
       const hook = await getWebhookResult(route);
@@ -351,7 +348,7 @@ describe('organization role data hook events', () => {
   it.each(organizationRoleDataHookTestCases)(
     'test case %#: %p',
     async ({ route, event, method, endpoint, payload }) => {
-      await authedAdminApi[method](
+      await authedApi[method](
         endpoint.replace('{organizationRoleId}', roleId).replace('{scopeId}', scopeId),
         { json: JSON.parse(JSON.stringify(payload).replace('{scopeId}', scopeId)) }
       );

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.interaction.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.interaction.test.ts
@@ -5,7 +5,7 @@ import {
   hookEvents,
 } from '@logto/schemas';
 
-import { authedAdminApi } from '#src/api/api.js';
+import { authedApi } from '#src/api/api.js';
 import { resetPasswordlessConnectors } from '#src/helpers/connector.js';
 import { WebHookApiTest } from '#src/helpers/hook.js';
 import {
@@ -140,7 +140,7 @@ describe('interaction api trigger hooks', () => {
     });
 
     // Clean up
-    await authedAdminApi.delete(`users/${userId}`);
+    await authedApi.delete(`users/${userId}`);
   });
 
   it('user sign in interaction API  without profile update', async () => {

--- a/packages/integration-tests/src/tests/api/interaction/register-with-identifier/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/register-with-identifier/happy-path.test.ts
@@ -318,7 +318,7 @@ describe('register with passwordless identifier', () => {
     });
 
     const client = await initClient();
-    assert(client.interactionCookie, new Error('Session not found'));
+    assert(client.sessionCookie, new Error('Session not found'));
 
     await client.successSend(putInteraction, {
       event: InteractionEvent.Register,

--- a/packages/integration-tests/src/tests/api/one-time-tokens.test.ts
+++ b/packages/integration-tests/src/tests/api/one-time-tokens.test.ts
@@ -1,7 +1,7 @@
 import { OneTimeTokenStatus } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 
-import { authedAdminApi } from '#src/api/api.js';
+import { authedApi } from '#src/api/api.js';
 import {
   createOneTimeToken,
   verifyOneTimeToken,
@@ -337,7 +337,7 @@ describe('one-time tokens API', () => {
     const tokens = await getOneTimeTokens();
     expect(tokens).toEqual(expect.arrayContaining([oneTimeToken1, oneTimeToken2, oneTimeToken3]));
 
-    const response = await authedAdminApi.get('one-time-tokens?page=1&page_size=2');
+    const response = await authedApi.get('one-time-tokens?page=1&page_size=2');
     expect(response.headers.get('Total-Number')).toBe('3');
     expect(await response.json()).toEqual(expect.arrayContaining([oneTimeToken2, oneTimeToken3]));
 

--- a/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
+++ b/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
@@ -2,7 +2,7 @@ import { MfaPolicy, OrganizationRequiredMfaPolicy, SignInIdentifier } from '@log
 import { HTTPError, type ResponsePromise } from 'ky';
 
 import {
-  authedAdminApi,
+  authedApi,
   createUser,
   deleteUser,
   getSignInExperience,
@@ -96,7 +96,7 @@ describe('password policy', () => {
 
   it('should throw if rejects user info is enabled but no user id is provided', async () => {
     try {
-      await authedAdminApi.post('sign-in-exp/default/check-password', {
+      await authedApi.post('sign-in-exp/default/check-password', {
         json: {
           password: 'johnny13',
         },
@@ -123,7 +123,7 @@ describe('password policy', () => {
     const user = await createUser({ name: 'Johnny' });
     await Promise.all([
       expectPasswordIssues(
-        authedAdminApi.post('sign-in-exp/default/check-password', {
+        authedApi.post('sign-in-exp/default/check-password', {
           json: {
             password: '123',
             userId: user.id,
@@ -136,7 +136,7 @@ describe('password policy', () => {
         ]
       ),
       expectPasswordIssues(
-        authedAdminApi.post('sign-in-exp/default/check-password', {
+        authedApi.post('sign-in-exp/default/check-password', {
           json: {
             password: 'johnny13',
             userId: user.id,
@@ -145,7 +145,7 @@ describe('password policy', () => {
         ['password_rejected.character_types', 'password_rejected.restricted.user_info']
       ),
       expectPasswordIssues(
-        authedAdminApi.post('sign-in-exp/default/check-password', {
+        authedApi.post('sign-in-exp/default/check-password', {
           json: {
             password: '123456aA',
             userId: user.id,
@@ -162,7 +162,7 @@ describe('password policy', () => {
     const user = await createUser({ name: 'Johnny' });
 
     await expect(
-      authedAdminApi
+      authedApi
         .post('sign-in-exp/default/check-password', {
           json: {
             password: generatePassword(),

--- a/packages/integration-tests/src/tests/api/well-known.test.ts
+++ b/packages/integration-tests/src/tests/api/well-known.test.ts
@@ -1,7 +1,7 @@
 import { type SignInExperience, type Translation, type SsoConnectorMetadata } from '@logto/schemas';
 import { HTTPError } from 'ky';
 
-import api, { adminTenantApi, authedAdminApi } from '#src/api/api.js';
+import api, { adminTenantApi, authedApi } from '#src/api/api.js';
 import { updateSignInExperience } from '#src/api/index.js';
 import { createSsoConnector, deleteSsoConnectorById } from '#src/api/sso-connector.js';
 import { newOidcSsoConnectorPayload } from '#src/constants.js';
@@ -55,7 +55,7 @@ describe('.well-known api', () => {
 
     expect(original.translation.list).not.toHaveProperty('and', and);
 
-    await authedAdminApi.put('custom-phrases/en', { json: { list: { and } } });
+    await authedApi.put('custom-phrases/en', { json: { list: { and } } });
     const updated = await api
       .get('.well-known/phrases?lng=en')
       .json<{ translation: Translation }>();

--- a/packages/integration-tests/src/tests/console/applications/index.test.ts
+++ b/packages/integration-tests/src/tests/console/applications/index.test.ts
@@ -226,11 +226,6 @@ describe('applications', () => {
   it.each(applicationTypesMetadata)(
     'can create and modify a(n) $type application without framework',
     async (app: ApplicationMetadata) => {
-      if (app.type === ApplicationType.Protected) {
-        // TODO @wangsijie: Remove this guard once protected app is ready
-        expect(true).toBe(true);
-        return;
-      }
 
       await expect(page).toClick('div[class$=main] div[class$=headline] button span', {
         text: 'Create application',


### PR DESCRIPTION
## Summary
- rename `interactionCookie` to `sessionCookie`
- rename `authedAdminApi` to `authedApi`
- test that SAML apps cannot be patched via applications API
- test membership update hook on user deletion
- remove protected app guard from console tests
- remove dev feature guard from data hook tests

## Testing
- `pnpm -r --parallel --workspace-concurrency=1 test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684caf673f38832f91e63f988205c74b