### PR TITLE
Add Slack failure notifications

### DIFF
--- a/.github/workflows/pen-tests.yml
+++ b/.github/workflows/pen-tests.yml
@@ -40,4 +40,13 @@ jobs:
           allow_issue_writing: false
           rules_file_name: ".zap/rules.conf"
 
-      # TODO: send slack message on failure
+      - name: Post failure details to Slack
+        if: failure()
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "text": "Pen Tests workflow failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ If you find Logto helpful, here's how you can support us:
 - 🙋 [Open an issue](https://github.com/logto-io/logto/issues/new) to report bugs or suggest features.
 - 💻 [Contribute to Logto](./CONTRIBUTING.md) - we'd love your help! Check out [Logto awesome](https://github.com/logto-io/logto/blob/master/AWESOME.md) of community-contributed resources.
 
+## CI
+
+GitHub Actions workflows can send failure notifications to Slack. Configure the
+`SLACK_WEBHOOK_URL` repository secret with an incoming webhook URL to enable
+these alerts.
+
 ## Refactor Notes
 
 - [Tenant usage refactor](./docs-ref/tenant-usage-refactor.md)


### PR DESCRIPTION
## Summary
- send failure details to Slack if pen tests job fails
- document `SLACK_WEBHOOK_URL` secret requirement

## Testing
- `pnpm ci:test` *(fails: vitest not found, packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_684caf69c754832f9fb9ec9d36872bd8