### PR TITLE
Fix lint warnings in cloud models

### DIFF
--- a/packages/cloud-models/src/index.ts
+++ b/packages/cloud-models/src/index.ts
@@ -3,7 +3,7 @@ export enum LogtoSkuType {
   AddOn = 'AddOn',
 }
 
-export interface NewSubscriptionQuota {
+export type NewSubscriptionQuota = {
   mauLimit: number | null;
   tokenLimit: number | null;
   applicationsLimit: number | null;
@@ -28,13 +28,10 @@ export interface NewSubscriptionQuota {
   samlApplicationsLimit: number | null;
   captchaEnabled: boolean;
   securityFeaturesEnabled: boolean;
-}
+};
 
-export interface LogtoSkuQuota extends NewSubscriptionQuota {
+export type LogtoSkuQuota = NewSubscriptionQuota & {
   ticketSupportResponseTime: number;
-}
+};
 
-export type LogtoSkuQuotaEntries = Array<[
-  keyof LogtoSkuQuota,
-  LogtoSkuQuota[keyof LogtoSkuQuota]
-]>;
+export type LogtoSkuQuotaEntries = Array<[keyof LogtoSkuQuota, LogtoSkuQuota[keyof LogtoSkuQuota]]>;


### PR DESCRIPTION
## Summary
- use types instead of interfaces for cloud models

## Testing
- `pnpm ci:lint` *(fails: @logto/connector-alipay-web lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(terminated due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_684ccac35224832f9238fc7e28f11e9d