### PR TITLE
Add user deletion membership hook test

### DIFF
--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.custom.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.custom.data.test.ts
@@ -134,7 +134,6 @@ describe('manual data hook tests', () => {
     });
 
   describe('organization membership update by just-in-time organization provisioning', () => {
-    // TODO: Add user deletion test case
 
     it('should trigger `Organization.Membership.Updated` event when user is provisioned by experience', async () => {
       await setEmailConnector();
@@ -189,6 +188,25 @@ describe('manual data hook tests', () => {
 
       const { id: userId } = await registerWithEmail(`${randomString()}@${domain}`);
       await organizationApi.deleteUser(organization.id, userId);
+
+      await assertOrganizationMembershipUpdated(organization.id);
+    });
+
+    it('should trigger `Organization.Membership.Updated` event when user is deleted', async () => {
+      await setEmailConnector();
+      await setSmsConnector();
+      await enableAllVerificationCodeSignInMethods({
+        identifiers: [SignInIdentifier.Email],
+        password: false,
+        verify: true,
+      });
+
+      const organization = await organizationApi.create({ name: 'qux' });
+      const domain = 'delete-user.com';
+      await organizationApi.jit.addEmailDomain(organization.id, domain);
+
+      const { id: userId } = await registerWithEmail(`${randomString()}@${domain}`);
+      await deleteUser(userId);
 
       await assertOrganizationMembershipUpdated(organization.id);
     });


### PR DESCRIPTION
## Summary
- finish TODO by adding user deletion case in manual data hook tests

## Testing
- `pnpm ci:lint` *(fails: eslint errors in connector packages)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(terminated due to long runtime)*
- `pnpm --filter @logto/integration-tests test` *(fails: build errors about missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684d84588578832fa0c11c22feb64039