### PR TITLE
Rename console helper

### DIFF
--- a/packages/integration-tests/src/tests/console/applications/index.test.ts
+++ b/packages/integration-tests/src/tests/console/applications/index.test.ts
@@ -10,7 +10,7 @@ import {
   expectToOpenNewPage,
   expectToSaveChanges,
   expectUnsavedChangesAlert,
-  goToAdminConsole,
+  goToConsole,
   waitForToast,
 } from '#src/ui-helpers/index.js';
 import { expectNavigation, appendPathname, dcls, waitFor, cls } from '#src/utils.js';
@@ -37,7 +37,7 @@ describe('applications', () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   it('navigate to applications page', async () => {

--- a/packages/integration-tests/src/tests/console/connectors/passwordless-connectors.test.ts
+++ b/packages/integration-tests/src/tests/console/connectors/passwordless-connectors.test.ts
@@ -4,7 +4,7 @@ import { logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
 import {
   expectToClickDetailsPageOption,
   expectUnsavedChangesAlert,
-  goToAdminConsole,
+  goToConsole,
   expectToSaveChanges,
   waitForToast,
 } from '#src/ui-helpers/index.js';
@@ -28,7 +28,7 @@ describe('passwordless connectors', () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   it('navigate to passwordless connector page', async () => {

--- a/packages/integration-tests/src/tests/console/connectors/social-connectors.test.ts
+++ b/packages/integration-tests/src/tests/console/connectors/social-connectors.test.ts
@@ -4,7 +4,7 @@ import { logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
 import {
   expectToClickDetailsPageOption,
   expectUnsavedChangesAlert,
-  goToAdminConsole,
+  goToConsole,
   expectToSaveChanges,
   waitForToast,
   expectModalWithTitle,
@@ -27,7 +27,7 @@ describe('social connectors', () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   it('navigate to social connector page', async () => {

--- a/packages/integration-tests/src/tests/console/mfa/index.test.ts
+++ b/packages/integration-tests/src/tests/console/mfa/index.test.ts
@@ -3,7 +3,7 @@ import {
   expectMainPageWithTitle,
   expectToClickSidebarMenu,
   expectToSaveChanges,
-  goToAdminConsole,
+  goToConsole,
   waitForToast,
 } from '#src/ui-helpers/index.js';
 
@@ -18,7 +18,7 @@ await page.setViewport({ width: 1920, height: 1080 });
 // Skip this test suite since it's not public yet
 describe.skip('multi-factor authentication', () => {
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   it('navigate to multi-factor authentication page', async () => {

--- a/packages/integration-tests/src/tests/console/rbac/machime-to-machime-rbac.test.ts
+++ b/packages/integration-tests/src/tests/console/rbac/machime-to-machime-rbac.test.ts
@@ -4,7 +4,7 @@ import {
   expectModalWithTitle,
   expectToClickModalAction,
   expectToClickNavTab,
-  goToAdminConsole,
+  goToConsole,
   waitForToast,
 } from '#src/ui-helpers/index.js';
 import {
@@ -44,7 +44,7 @@ describe('M2M RBAC', () => {
   const m2mFramework = 'Machine-to-machine';
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   describe('create api resource and permissions', () => {

--- a/packages/integration-tests/src/tests/console/rbac/user-rbac.test.ts
+++ b/packages/integration-tests/src/tests/console/rbac/user-rbac.test.ts
@@ -5,7 +5,7 @@ import {
   expectToClickDetailsPageOption,
   expectToClickModalAction,
   expectToClickNavTab,
-  goToAdminConsole,
+  goToConsole,
   waitForToast,
 } from '#src/ui-helpers/index.js';
 import {
@@ -34,7 +34,7 @@ describe('User RBAC', () => {
   const rbacTestUsername = generateUsername();
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   it('navigate to api resources page', async () => {

--- a/packages/integration-tests/src/tests/console/sign-in-experience/branding.test.ts
+++ b/packages/integration-tests/src/tests/console/sign-in-experience/branding.test.ts
@@ -1,5 +1,5 @@
 import { logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
-import { goToAdminConsole } from '#src/ui-helpers/index.js';
+import { goToConsole } from '#src/ui-helpers/index.js';
 import { expectNavigation, appendPathname, waitFor } from '#src/utils.js';
 
 import { waitForFormCard, expectToSelectColor, expectToSaveSignInExperience } from './helpers.js';
@@ -13,7 +13,7 @@ describe('sign-in experience: branding', () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   it('navigate to sign-in experience page', async () => {

--- a/packages/integration-tests/src/tests/console/sign-in-experience/sign-in-preview.test.ts
+++ b/packages/integration-tests/src/tests/console/sign-in-experience/sign-in-preview.test.ts
@@ -2,7 +2,7 @@ import { type Nullable } from '@silverhand/essentials';
 import { type Page, type Target } from 'puppeteer';
 
 import { logtoConsoleUrl as logtoConsoleUrlString, logtoUrl } from '#src/constants.js';
-import { goToAdminConsole } from '#src/ui-helpers/index.js';
+import { goToConsole } from '#src/ui-helpers/index.js';
 import { expectNavigation, appendPathname } from '#src/utils.js';
 
 import { expectToSelectPreviewLanguage, waitForFormCard } from './helpers.js';
@@ -13,7 +13,7 @@ describe('sign-in experience: sign-in preview', () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   it('navigate to sign-in experience page', async () => {

--- a/packages/integration-tests/src/tests/console/sign-in-experience/sign-up-and-sign-in/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/console/sign-in-experience/sign-up-and-sign-in/happy-path.test.ts
@@ -1,5 +1,5 @@
 import { logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
-import { expectToClickNavTab, goToAdminConsole } from '#src/ui-helpers/index.js';
+import { expectToClickNavTab, goToConsole } from '#src/ui-helpers/index.js';
 import { expectNavigation, appendPathname, waitFor } from '#src/utils.js';
 
 import { expectToSaveSignInExperience, waitForFormCard } from '../helpers.js';
@@ -30,7 +30,7 @@ describe('sign-in experience(happy path): sign-up and sign-in', () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
     // Email connector
     await expectToSetupPasswordlessConnector(page, testSendgridConnector);
     // SMS connector

--- a/packages/integration-tests/src/tests/console/sign-in-experience/sign-up-and-sign-in/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/console/sign-in-experience/sign-up-and-sign-in/sad-path.test.ts
@@ -1,5 +1,5 @@
 import { logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
-import { expectToClickNavTab, goToAdminConsole } from '#src/ui-helpers/index.js';
+import { expectToClickNavTab, goToConsole } from '#src/ui-helpers/index.js';
 import { expectNavigation, appendPathname } from '#src/utils.js';
 
 import { waitForFormCard } from '../helpers.js';
@@ -10,7 +10,7 @@ describe('sign-in experience(sad path): sign-up and sign-in', () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   it('navigate to sign-in experience page', async () => {

--- a/packages/integration-tests/src/tests/console/sso-connectors/sso-connectors.test.ts
+++ b/packages/integration-tests/src/tests/console/sso-connectors/sso-connectors.test.ts
@@ -1,7 +1,7 @@
 import { getSsoConnectors, deleteSsoConnectorById } from '#src/api/sso-connector.js';
 import { logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
 import {
-  goToAdminConsole,
+  goToConsole,
   expectModalWithTitle,
   expectConfirmModalAndAct,
   expectToClickDetailsPageOption,
@@ -30,7 +30,7 @@ describe('create SSO connectors', () => {
 
   beforeAll(async () => {
     // Enter admin console
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   afterAll(async () => {

--- a/packages/integration-tests/src/tests/console/user-management.test.ts
+++ b/packages/integration-tests/src/tests/console/user-management.test.ts
@@ -1,6 +1,6 @@
 import { logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
 import {
-  goToAdminConsole,
+  goToConsole,
   expectToSaveChanges,
   waitForToast,
   expectToDiscardChanges,
@@ -25,7 +25,7 @@ describe('user management', () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   it('navigates to user management page on clicking sidebar menu', async () => {

--- a/packages/integration-tests/src/tests/console/webhooks/index.test.ts
+++ b/packages/integration-tests/src/tests/console/webhooks/index.test.ts
@@ -6,7 +6,7 @@ import {
   expectToClickDetailsPageOption,
   expectToClickModalAction,
   expectToSaveChanges,
-  goToAdminConsole,
+  goToConsole,
   waitForToast,
 } from '#src/ui-helpers/index.js';
 import { appendPathname, dcls, expectNavigation } from '#src/utils.js';
@@ -19,7 +19,7 @@ describe('webhooks', () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
 
   beforeAll(async () => {
-    await goToAdminConsole();
+    await goToConsole();
   });
 
   it('navigates to webhooks page on clicking sidebar menu', async () => {

--- a/packages/integration-tests/src/ui-helpers/index.ts
+++ b/packages/integration-tests/src/ui-helpers/index.ts
@@ -21,7 +21,7 @@ import { selectDropdownMenuItem } from './select-dropdown-menu-item.js';
 
 export type PuppeteerInstance = Page | Frame | ElementHandle;
 
-export const goToAdminConsole = async () => {
+export const goToConsole = async () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
   await expectNavigation(page.goto(logtoConsoleUrl.href));
 


### PR DESCRIPTION
## Summary
- rename `goToAdminConsole` to `goToConsole`
- update imports in integration tests

## Testing
- `pnpm ci:lint` *(fails: @logto/connector-alipay-web lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_684d8455d758832f9ca35e110be1d2af