### PR TITLE
Add branding cleanup test

### DIFF
--- a/packages/console/src/__tests__/branding-cleanup.test.ts
+++ b/packages/console/src/__tests__/branding-cleanup.test.ts
@@ -1,0 +1,27 @@
+import { cleanDeep } from '@logto/shared/universal';
+import { SyncProfileMode } from '@/types/connector';
+import { formDataToSsoConnectorParser, type FormType } from '../pages/EnterpriseSsoDetails/Experience';
+
+describe('branding cleanup on submit', () => {
+  const baseFormData: FormType = {
+    connectorName: 'name',
+    branding: { displayName: '', logo: '', darkLogo: '' },
+    domains: [{ id: '1', value: 'example.com' }],
+    syncProfile: SyncProfileMode.OnlyAtRegister,
+  };
+
+  it('should clean up empty branding fields', () => {
+    const parsed = cleanDeep(formDataToSsoConnectorParser(baseFormData), { emptyObjects: false });
+    expect(parsed.branding).toEqual({});
+  });
+
+  it('should keep non-empty branding fields', () => {
+    const formData: FormType = {
+      ...baseFormData,
+      branding: { displayName: 'Foo', logo: '', darkLogo: '' },
+    };
+
+    const parsed = cleanDeep(formDataToSsoConnectorParser(formData), { emptyObjects: false });
+    expect(parsed.branding).toEqual({ displayName: 'Foo' });
+  });
+});

--- a/packages/console/src/pages/EnterpriseSsoDetails/Experience/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Experience/index.tsx
@@ -64,7 +64,7 @@ const dataToFormParser = (data: DataType) => {
   };
 };
 
-const formDataToSsoConnectorParser = (
+export const formDataToSsoConnectorParser = (
   formData: FormType
 ): Pick<SsoConnector, 'branding' | 'connectorName' | 'domains' | 'syncProfile'> => {
   const { branding, connectorName, domains, syncProfile } = formData;


### PR DESCRIPTION
## Summary
- export `formDataToSsoConnectorParser`
- add unit test for cleaning `branding` fields on submit

## Testing
- `pnpm ci:lint` *(fails: connector packages lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: connector packages test suites)*

------
https://chatgpt.com/codex/tasks/task_e_684d845302b0832f9993d03d482b0710