### PR TITLE
Clarify koaApiHooks middleware usage

### DIFF
--- a/docs-ref/koa-api-hooks.md
+++ b/docs-ref/koa-api-hooks.md
@@ -1,0 +1,16 @@
+# API Hooks Middleware
+
+**File paths**
+- `packages/core/src/middleware/koa-api-hooks.ts`
+- `packages/core/src/routes/init.ts`
+- `packages/core/src/routes/account/index.ts`
+- `packages/core/src/middleware/koa-api-hooks.test.ts`
+
+**Key changes**
+- Documented that `koaApiHooks` is shared across Management and user Account APIs.
+- Management API routes rely on `managementApiHooksRegistration` to append events automatically.
+- User Account routes append contexts manually with `ctx.appendDataHookContext`.
+- Updated comments and tests to reflect the behavior.
+
+**New dependencies / environment variables**
+- None.

--- a/packages/core/src/middleware/koa-api-hooks.test.ts
+++ b/packages/core/src/middleware/koa-api-hooks.test.ts
@@ -31,7 +31,8 @@ describe('koaApiHooks', () => {
     expect(triggerDataHooks).not.toBeCalled();
   });
 
-  it('should trigger management hooks', async () => {
+  // Covers usage on user APIs where the context is appended manually
+  it('should trigger data hooks when context is appended', async () => {
     const ctx: ParameterizedContext<unknown, WithHookContext> = {
       ...createContextWithRouteParameters(),
       header: {},

--- a/packages/core/src/middleware/koa-api-hooks.ts
+++ b/packages/core/src/middleware/koa-api-hooks.ts
@@ -10,9 +10,14 @@ export type WithHookContext<ContextT extends IRouterParamContext = IRouterParamC
   ContextT & { appendDataHookContext: DataHookContextManager['appendContext'] };
 
 /**
- * The factory to create a new management hook middleware function.
+ * Factory for the API hook middleware.
  *
- * To trigger management hooks, use `appendDataHookContext` to append the context.
+ * Used by both the Management API and the user Account API. The middleware
+ * collects contexts for DataHook events. User routes manually append contexts
+ * while Management API routes may register events that are appended
+ * automatically.
+ *
+ * To trigger hooks, call `ctx.appendDataHookContext` in a route handler.
  *
  * @param hooks The hooks library.
  * @returns The middleware function.
@@ -29,14 +34,15 @@ export const koaApiHooks = <StateT, ContextT extends IRouterParamContext, Respon
     const dataHooksContextManager = new DataHookContextManager({ userAgent, ip });
 
     /**
-     * Append a hook context to trigger management hooks. If multiple contexts are appended, all of
-     * them will be triggered.
+     * Append a hook context to trigger data hooks. If multiple contexts are
+     * appended, all of them will be triggered.
      */
     ctx.appendDataHookContext = dataHooksContextManager.appendContext.bind(dataHooksContextManager);
 
     await next();
 
-    // Auto append pre-registered management API hooks if any
+    // Auto append pre-registered management API hooks if any. Only management
+    // API routes are registered for automatic triggering.
     const registeredData = dataHooksContextManager.getRegisteredDataHookEventContext(ctx);
 
     if (registeredData) {

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -99,7 +99,8 @@ const createRouters = (tenant: TenantContext) => {
 
   const userRouter: UserRouter = new Router();
   userRouter.use(koaOidcAuth(tenant));
-  // TODO(LOG-10147): koaApiHooks middleware is used for both management API and user API
+  // The same middleware is shared with the management API so account routes can
+  // also trigger DataHook events (e.g. User.Data.Updated) after a user action.
   userRouter.use(koaApiHooks(tenant.libraries.hooks));
   accountRoutes(userRouter, tenant);
   verificationRoutes(userRouter, tenant);


### PR DESCRIPTION
## Summary
- document API hooks middleware usage
- clarify comments in `koaApiHooks` and `init.ts`
- rename test to highlight user API usage

## Testing
- `pnpm ci:lint` *(fails: eslint errors in connector packages)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: connector test suites could not resolve modules)*

------
https://chatgpt.com/codex/tasks/task_e_684d844859bc832fbcb666d3deb51d08