### PR TITLE
core: share identify user helper

### DIFF
--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -21,7 +21,7 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { findUserByIdentifier } from '../utils.js';
+import { identifyUserByIdentifier } from './shared/identify-user.js';
 
 import { type IdentifierVerificationRecord } from './verification-record.js';
 
@@ -136,24 +136,11 @@ abstract class CodeVerification<T extends CodeVerificationType>
   }
 
   async identifyUser(): Promise<User> {
-    assertThat(
+    return identifyUserByIdentifier(
+      this.queries,
       this.verified,
-      new RequestError({ code: 'session.verification_failed', status: 400 })
+      this.identifier
     );
-
-    const user = await findUserByIdentifier(this.queries.users, this.identifier);
-
-    assertThat(
-      user,
-      new RequestError(
-        { code: 'user.user_not_exist', status: 404 },
-        {
-          identifier: this.identifier.value,
-        }
-      )
-    );
-
-    return user;
   }
 
   toJson(): CodeVerificationRecordData<T> {

--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -14,7 +14,7 @@ import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import { type InteractionProfile } from '../../types.js';
-import { findUserByIdentifier } from '../utils.js';
+import { identifyUserByIdentifier } from './shared/identify-user.js';
 
 import { type IdentifierVerificationRecord } from './verification-record.js';
 
@@ -86,22 +86,11 @@ export class OneTimeTokenVerification
   }
 
   async identifyUser(): Promise<User> {
-    assertThat(
+    return identifyUserByIdentifier(
+      this.queries,
       this.verified,
-      new RequestError({ code: 'session.verification_failed', status: 400 })
+      this.identifier
     );
-
-    const user = await findUserByIdentifier(this.queries.users, this.identifier);
-
-    assertThat(
-      user,
-      new RequestError(
-        { code: 'user.user_not_exist', status: 404 },
-        { identifier: this.identifier }
-      )
-    );
-
-    return user;
   }
 
   toUserProfile(): InteractionProfile {

--- a/packages/core/src/routes/experience/classes/verifications/password-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/password-verification.ts
@@ -11,7 +11,7 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { findUserByIdentifier } from '../utils.js';
+import { identifyUserByIdentifier } from './shared/identify-user.js';
 
 import { type IdentifierVerificationRecord } from './verification-record.js';
 
@@ -81,24 +81,11 @@ export class PasswordVerification
   }
 
   async identifyUser(): Promise<User> {
-    assertThat(
+    return identifyUserByIdentifier(
+      this.queries,
       this.verified,
-      new RequestError({ code: 'session.verification_failed', status: 400 })
+      this.identifier
     );
-
-    const user = await findUserByIdentifier(this.queries.users, this.identifier);
-
-    assertThat(
-      user,
-      new RequestError(
-        { code: 'user.user_not_exist', status: 404 },
-        {
-          identifier: this.identifier.value,
-        }
-      )
-    );
-
-    return user;
   }
 
   toJson(): PasswordVerificationRecordData {

--- a/packages/core/src/routes/experience/classes/verifications/shared/identify-user.ts
+++ b/packages/core/src/routes/experience/classes/verifications/shared/identify-user.ts
@@ -1,0 +1,29 @@
+import { type VerificationIdentifier, type User } from '@logto/schemas';
+import type Queries from '#src/tenants/Queries.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import { findUserByIdentifier } from '../../utils.js';
+
+export const identifyUserByIdentifier = async (
+  queries: Queries,
+  verified: boolean,
+  identifier: VerificationIdentifier
+): Promise<User> => {
+  assertThat(
+    verified,
+    new RequestError({ code: 'session.verification_failed', status: 400 })
+  );
+
+  const user = await findUserByIdentifier(queries.users, identifier);
+
+  assertThat(
+    user,
+    new RequestError(
+      { code: 'user.user_not_exist', status: 404 },
+      { identifier: identifier.value }
+    )
+  );
+
+  return user;
+};


### PR DESCRIPTION
## Summary
- extract common helper to identify users by identifier
- refactor password/code/one-time-token verifications to use helper

## Testing
- `pnpm ci:lint` *(fails: ESLint couldn't find config in several packages)*
- `pnpm ci:test` *(fails: tests fail during connector packages)*

------
https://chatgpt.com/codex/tasks/task_e_684d844083b0832fbf866f640700df99