### PR TITLE
Update CAPTCHA validation threshold

### DIFF
--- a/packages/console/src/pages/CaptchaDetails/CaptchaContent/index.tsx
+++ b/packages/console/src/pages/CaptchaDetails/CaptchaContent/index.tsx
@@ -34,7 +34,7 @@ function CaptchaContent({ isDeleted, captchaProvider, onUpdate }: Props) {
     reValidateMode: 'onBlur',
     defaultValues: {
       ...captchaProvider.config,
-      scoreThreshold: captchaProvider.config.scoreThreshold ?? 0.5,
+      scoreThreshold: captchaProvider.config.scoreThreshold ?? 0.7,
     },
   });
 

--- a/packages/console/src/pages/Security/Captcha/Guide/index.tsx
+++ b/packages/console/src/pages/Security/Captcha/Guide/index.tsx
@@ -43,7 +43,7 @@ function Guide({ type, onClose }: Props) {
       siteKey: '',
       secretKey: '',
       projectId: '',
-      scoreThreshold: 0.5,
+      scoreThreshold: 0.7,
     },
   });
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -25,3 +25,7 @@ npx redoc-cli serve http://localhost:3001/api/swagger.json
 ### Using Swagger editor
 
 Copy the API output and paste it in the [Swagger Editor](https://editor.swagger.io/).
+
+## CAPTCHA verification
+
+The default score threshold for reCAPTCHA Enterprise is **0.7**. You can override this value via `scoreThreshold` in the CAPTCHA provider configuration.

--- a/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
@@ -112,7 +112,7 @@ export class CaptchaValidator {
         riskAnalysis: { score },
       } = responseGuard.parse(result);
 
-      const success = valid && score >= (config.scoreThreshold ?? 0.5);
+      const success = valid && score >= (config.scoreThreshold ?? 0.7);
 
       this.log.append({
         success,

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- feat: allow tenants to configure acceptable CAPTCHA scores with `scoreThreshold` in reCAPTCHA Enterprise. Default value is `0.5`.
+- feat: allow tenants to configure acceptable CAPTCHA scores with `scoreThreshold` in reCAPTCHA Enterprise. Default value is `0.7`.
 
 ## 1.28.0
 

--- a/packages/schemas/src/foundations/jsonb-types/captcha.ts
+++ b/packages/schemas/src/foundations/jsonb-types/captcha.ts
@@ -19,7 +19,7 @@ export const recaptchaEnterpriseConfigGuard = z.object({
   secretKey: z.string(),
   projectId: z.string(),
   /** The minimum acceptable score returned from reCAPTCHA Enterprise. */
-  scoreThreshold: z.number().min(0).max(1).optional().default(0.5),
+  scoreThreshold: z.number().min(0).max(1).optional().default(0.7),
 });
 
 export type RecaptchaEnterpriseConfig = z.infer<typeof recaptchaEnterpriseConfigGuard>;


### PR DESCRIPTION
## Summary
- raise CAPTCHA score threshold to 0.7
- document the default threshold in core README

## Testing
- `pnpm ci:lint` *(fails: @logto/connector-alipay-web lint issues)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: packages/schemas precommit script)*


------
https://chatgpt.com/codex/tasks/task_e_684d843ddb54832f8fd3aa374446dba2