### PR TITLE
Fix hook payload user info

### DIFF
--- a/packages/core/src/libraries/hook/index.test.ts
+++ b/packages/core/src/libraries/hook/index.test.ts
@@ -63,18 +63,11 @@ const findApplicationById = jest.fn().mockResolvedValue({ id: 'app_id', extraFie
 
 const { createHookLibrary } = await import('./index.js');
 const mockUserLibrary = {
-  findUserSsoIdentities: jest.fn().mockResolvedValue([]),
+  getUserInfo: jest.fn().mockResolvedValue({ id: 'user_id', username: 'user' }),
 };
 
 const { triggerInteractionHooks, triggerTestHook, triggerDataHooks } = createHookLibrary(
   new MockQueries({
-    users: {
-      findUserById: jest.fn().mockReturnValue({
-        id: 'user_id',
-        username: 'user',
-        extraField: 'not_ok',
-      }),
-    },
     applications: {
       findApplicationById,
     },
@@ -110,6 +103,7 @@ describe('triggerInteractionHooks()', () => {
 
     expect(findAllHooks).toHaveBeenCalled();
     expect(findApplicationById).toHaveBeenCalledWith('some_client');
+    expect(mockUserLibrary.getUserInfo).toHaveBeenCalledWith('123');
     expect(sendWebhookRequest).toHaveBeenCalledWith({
       hookConfig: hook.config,
       payload: {
@@ -118,7 +112,7 @@ describe('triggerInteractionHooks()', () => {
         interactionEvent: 'SignIn',
         sessionId: interactionHookContext.metadata.sessionId,
         userId: '123',
-        user: { id: 'user_id', username: 'user' },
+        user: { id: 'user_id', username: 'user', hasPassword: false },
         application: { id: 'app_id' },
         createdAt: new Date(100_000).toISOString(),
       },

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -36,8 +36,7 @@ export const createHookLibrary = (queries: Queries, userLibrary: UserLibrary) =>
   const {
     applications: { findApplicationById },
     logs: { insertLog },
-    // TODO: @gao should we use the library function thus we can pass full userinfo to the payload?
-    users: { findUserById },
+    // Use userLibrary.getUserInfo for full user information in payloads
     hooks: { findAllHooks, findHookById },
   } = queries;
 
@@ -126,11 +125,7 @@ export const createHookLibrary = (queries: Queries, userLibrary: UserLibrary) =>
     }
 
     const [user, application] = await Promise.all([
-      trySafe(async () => {
-        const found = await findUserById(userId);
-        const ssoIdentities = await userLibrary.findUserSsoIdentities(userId);
-        return transpileUserProfileResponse(found, { ssoIdentities });
-      }),
+      trySafe(async () => userLibrary.getUserInfo(userId)),
       trySafe(async () => conditional(applicationId && (await findApplicationById(applicationId)))),
     ]);
 


### PR DESCRIPTION
## Summary
- use `getUserInfo` when building hook payloads
- adjust tests for new function

## Testing
- `pnpm ci:lint` *(fails: connector lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(failed: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684d8435bb84832fad08b938880fa534