### PR TITLE
Validate social connectors in sign-in

### DIFF
--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@logto/schemas';
 
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
+import { mockGithubConnector } from '#src/__mocks__/connector.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
@@ -34,6 +35,9 @@ const ssoConnectors = {
 };
 
 const mockTenant = new MockTenant(undefined, { signInExperiences }, undefined, { ssoConnectors });
+mockTenant.setPartialKey('libraries', 'socials', {
+  getConnector: jest.fn().mockResolvedValue(mockGithubConnector),
+});
 
 const passwordVerificationRecords = Object.fromEntries(
   Object.values(SignInIdentifier).map((identifier) => [
@@ -305,6 +309,20 @@ describe('SignInExperienceValidator', () => {
             accepted: false,
           },
         ],
+      },
+      'social connector allowed': {
+        signInExperience: {
+          ...mockSignInExperience,
+          socialSignInConnectorTargets: ['github'],
+        },
+        cases: [{ verificationRecord: socialVerificationRecord, accepted: true }],
+      },
+      'social connector not allowed': {
+        signInExperience: {
+          ...mockSignInExperience,
+          socialSignInConnectorTargets: [],
+        },
+        cases: [{ verificationRecord: socialVerificationRecord, accepted: false }],
       },
     });
 


### PR DESCRIPTION
## Summary
- ensure social sign-in connectors are allowed before accepting verification records
- format test cases for allowed and disallowed social connectors

## Testing
- `pnpm ci:lint` *(fails: connector packages lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(failed: connector dingtalk web tests)*

------
https://chatgpt.com/codex/tasks/task_e_684d84471104832f9dfa51bfba7c364e