### PR TITLE
Fix Azure AD connector tests

### DIFF
--- a/packages/toolkit/connector-kit/src/types/config-form.ts
+++ b/packages/toolkit/connector-kit/src/types/config-form.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { i18nPhrasesGuard } from './metadata.js';
+import { i18nPhrasesGuard } from './i18n.js';
 
 export enum ConnectorConfigFormItemType {
   Text = 'Text',
@@ -29,9 +29,7 @@ const baseConfigFormItem = {
 export const connectorConfigFormItemGuard = z.discriminatedUnion('type', [
   z.object({
     type: z.literal(ConnectorConfigFormItemType.Select),
-    selectItems: z.array(
-      z.object({ value: z.string(), title: z.string().or(i18nPhrasesGuard) })
-    ),
+    selectItems: z.array(z.object({ value: z.string(), title: z.string().or(i18nPhrasesGuard) })),
     ...baseConfigFormItem,
   }),
   z.object({

--- a/packages/toolkit/connector-kit/src/types/i18n.ts
+++ b/packages/toolkit/connector-kit/src/types/i18n.ts
@@ -1,0 +1,27 @@
+import type { LanguageTag } from '@logto/language-kit';
+import { isLanguageTag } from '@logto/language-kit';
+import type { ZodType } from 'zod';
+import { z } from 'zod';
+
+export type I18nPhrases = { en: string } & {
+  [K in Exclude<LanguageTag, 'en'>]?: string;
+};
+
+export const i18nPhrasesGuard: ZodType<I18nPhrases> = z
+  .object({ en: z.string() })
+  .and(z.record(z.string()))
+  .refine((i18nObject) => {
+    const keys = Object.keys(i18nObject);
+
+    if (!keys.includes('en')) {
+      return false;
+    }
+
+    for (const value of keys) {
+      if (!isLanguageTag(value)) {
+        return false;
+      }
+    }
+
+    return true;
+  });

--- a/packages/toolkit/connector-kit/src/types/metadata.ts
+++ b/packages/toolkit/connector-kit/src/types/metadata.ts
@@ -1,40 +1,15 @@
-import type { LanguageTag } from '@logto/language-kit';
-import { isLanguageTag } from '@logto/language-kit';
 import { type Nullable } from '@silverhand/essentials';
-import type { ZodType } from 'zod';
 import { z } from 'zod';
 
 import { connectorConfigFormItemGuard } from './config-form.js';
 import { type ToZodObject } from './foundation.js';
+import { type I18nPhrases, i18nPhrasesGuard } from './i18n.js';
 
 export enum ConnectorPlatform {
   Native = 'Native',
   Universal = 'Universal',
   Web = 'Web',
 }
-
-export const i18nPhrasesGuard: ZodType<I18nPhrases> = z
-  .object({ en: z.string() })
-  .and(z.record(z.string()))
-  .refine((i18nObject) => {
-    const keys = Object.keys(i18nObject);
-
-    if (!keys.includes('en')) {
-      return false;
-    }
-
-    for (const value of keys) {
-      if (!isLanguageTag(value)) {
-        return false;
-      }
-    }
-
-    return true;
-  });
-
-export type I18nPhrases = { en: string } & {
-  [K in Exclude<LanguageTag, 'en'>]?: string;
-};
 
 export type SocialConnectorMetadata = {
   platform?: ConnectorPlatform;


### PR DESCRIPTION
## Summary
- break circular import in connector-kit by moving i18n guard to its own module
- update metadata and config-form modules to use new i18n guard

## Testing
- `pnpm --filter @logto/connector-azuread test -- --run`
- `pnpm ci:lint` *(fails: Unsafe assignment in connector-alipay-native)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: connector-facebook could not resolve module)*

------
https://chatgpt.com/codex/tasks/task_e_684d842ba050832fa1af2902111c782b