### PR TITLE
docs: add GSI_CORP_SUPPORTED

### DIFF
--- a/docs-ref/coep-token-revocation.md
+++ b/docs-ref/coep-token-revocation.md
@@ -10,4 +10,6 @@
 - Updated token revocation logging to include user information extracted from access or refresh tokens.
 
 **New dependencies / environment variables**
-- None.
+- Added `GSI_CORP_SUPPORTED` to toggle the Google One Tap CORP header.
+
+> **Note**: Keep an eye on Google announcements and update the default once CORP is officially supported.

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -3,3 +3,9 @@
 The shared package for **non-business** components. For Logto business related stuff, put it to one of the packages in `packages/toolkit/`.
 
 The main import includes all components which may require Node. Import `@logto/shared/universal` for the universal bundle.
+
+## Environment variables
+
+`GSI_CORP_SUPPORTED`
+
+: Toggle support for the Google One Tap CORP header. Defaults to `true`. Set to a falsy value to disable the `Cross-Origin-Embedder-Policy` header until Google officially documents CORP support.


### PR DESCRIPTION
## Summary
- document `GSI_CORP_SUPPORTED` environment variable
- note to monitor Google CORP support in coep token revocation doc

## Testing
- `pnpm ci:lint` *(fails: connector-alipay-web lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models and connectors tests)*

------
https://chatgpt.com/codex/tasks/task_e_684eb438136c832f8b1337594ac8cde9