### PR TITLE
core: clarify koaApiHooks integration

### DIFF
--- a/docs-ref/koa-api-hooks.md
+++ b/docs-ref/koa-api-hooks.md
@@ -14,3 +14,31 @@
 
 **New dependencies / environment variables**
 - None.
+
+## Usage
+
+`koaApiHooks` gathers context for DataHook events and triggers hooks after the
+request cycle. Mount the middleware on both Management and user Account routers.
+
+### Management API
+
+```ts
+const managementRouter = new Router();
+managementRouter.use(koaApiHooks(tenant.libraries.hooks));
+// Events defined in `managementApiHooksRegistration` will be appended
+// automatically based on the route and HTTP method.
+```
+
+### Account API
+
+```ts
+const userRouter = new Router();
+userRouter.use(koaApiHooks(tenant.libraries.hooks));
+
+userRouter.patch('/account', async (ctx) => {
+  // Update the user here
+  ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });
+});
+```
+
+The middleware triggers `hooks.triggerDataHooks` once all contexts are appended.

--- a/packages/core/src/middleware/koa-api-hooks.test.ts
+++ b/packages/core/src/middleware/koa-api-hooks.test.ts
@@ -58,6 +58,32 @@ describe('koaApiHooks', () => {
     );
   });
 
+  it('should trigger data hooks for multiple contexts', async () => {
+    const ctx: ParameterizedContext<unknown, WithHookContext> = {
+      ...createContextWithRouteParameters(),
+      header: {},
+      appendDataHookContext: notToBeCalled,
+    };
+
+    next.mockImplementation(() => {
+      ctx.appendDataHookContext('Role.Created', { data: { id: '1' } });
+      ctx.appendDataHookContext('Role.Data.Updated', { data: { id: '1' } });
+    });
+
+    await koaApiHooks(mockHooksLibrary)(ctx, next);
+
+    expect(triggerDataHooks).toBeCalledTimes(1);
+    expect(triggerDataHooks).toBeCalledWith(
+      expect.any(ConsoleLog),
+      expect.objectContaining({
+        contextArray: [
+          { event: 'Role.Created', data: { id: '1' } },
+          { event: 'Role.Data.Updated', data: { id: '1' } },
+        ],
+      })
+    );
+  });
+
   describe('auto append pre-registered management API hooks', () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/packages/core/src/middleware/koa-api-hooks.ts
+++ b/packages/core/src/middleware/koa-api-hooks.ts
@@ -19,6 +19,8 @@ export type WithHookContext<ContextT extends IRouterParamContext = IRouterParamC
  *
  * To trigger hooks, call `ctx.appendDataHookContext` in a route handler.
  *
+ * @see ../../../../docs-ref/koa-api-hooks.md
+ *
  * @param hooks The hooks library.
  * @returns The middleware function.
  */


### PR DESCRIPTION
## Summary
- expand koaApiHooks reference docs with usage examples
- reference docs from middleware JSDoc
- illustrate multiple hook contexts in tests

## Testing
- `pnpm ci:lint` *(fails: connector packages lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models package tests)*

------
https://chatgpt.com/codex/tasks/task_e_684eb4328a80832f92ab76303abc2071