### PR TITLE
Enable MFA console integration tests

### DIFF
--- a/docs-ref/console-mfa-tests.md
+++ b/docs-ref/console-mfa-tests.md
@@ -1,0 +1,11 @@
+# Console MFA Tests
+
+**File paths**
+- `packages/integration-tests/src/tests/console/mfa/index.test.ts`
+
+**Key changes**
+- Enabled the multi-factor authentication console integration tests by removing the `describe.skip` flag.
+- Tests cover updating MFA factors and policy via the admin console.
+
+**New dependencies / environment variables**
+- None.

--- a/packages/integration-tests/src/tests/console/mfa/index.test.ts
+++ b/packages/integration-tests/src/tests/console/mfa/index.test.ts
@@ -15,8 +15,7 @@ import {
 
 await page.setViewport({ width: 1920, height: 1080 });
 
-// Skip this test suite since it's not public yet
-describe.skip('multi-factor authentication', () => {
+describe('multi-factor authentication', () => {
   beforeAll(async () => {
     await goToConsole();
   });


### PR DESCRIPTION
## Summary
- unskip MFA integration tests for console
- document new coverage in docs-ref

## Testing
- `pnpm ci:lint` *(fails: connector packages lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models package has no test files)*

------
https://chatgpt.com/codex/tasks/task_e_684eb43ddbe4832f865f69eca129bef4