### PR TITLE
Fix typos across repo

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -48,9 +48,9 @@
 
 ### Patch Changes
 
-- cb261024b: fix cli add offical connectors command missing connectors bug
+- cb261024b: fix cli add official connectors command missing connectors bug
 
-  Fix the bug when running the cli commend `logto connectors add --official`, only 8 connectors are fetched from npm registry.
+  Fix the bug when running the cli command `logto connectors add --official`, only 8 connectors are fetched from npm registry.
   This fix update logic to query additional pages of results when fetching connectors from the npm registry.
 
 - e11e57de8: bump dependencies for security update

--- a/packages/cli/src/commands/database/alteration/index.ts
+++ b/packages/cli/src/commands/database/alteration/index.ts
@@ -84,7 +84,7 @@ const deployAlteration = async (
 
     await pool.end();
     consoleLog.fatal(
-      `Error ocurred during running alteration ${chalk.blue(filename)}.\n\n` +
+      `Error occurred during running alteration ${chalk.blue(filename)}.\n\n` +
         "  This alteration didn't change anything since it was in a transaction.\n" +
         '  Try to fix the error and deploy again.'
     );

--- a/packages/cli/src/commands/database/seed/index.ts
+++ b/packages/cli/src/commands/database/seed/index.ts
@@ -116,7 +116,7 @@ const seed: CommandModule<
     } catch (error: unknown) {
       consoleLog.error(error);
       consoleLog.error(
-        'Error ocurred during seeding your database.\n\n' +
+        'Error occurred during seeding your database.\n\n' +
           '  Nothing has changed since the seeding process was in a transaction.\n' +
           '  Try to fix the error and seed again.'
       );

--- a/packages/connectors/connector-kakao/README.md
+++ b/packages/connectors/connector-kakao/README.md
@@ -4,7 +4,7 @@ The Kakao connector provides a succinct way for your application to use Kakao’
 
 **Table of contents**
 - [Kakao Connector](#kakao-connector)
-  - [Set up a project in the Kakao Devlopers Console](#set-up-a-project-in-the-kakao-devlopers-console)
+  - [Set up a project in the Kakao Developers Console](#set-up-a-project-in-the-kakao-developers-console)
   - [Configure Kakao Login](#configure-kakao-login)
     - [Activate Kakao Login](#activate-kakao-login)
     - [Privacy Setting](#privacy-setting)
@@ -12,9 +12,9 @@ The Kakao connector provides a succinct way for your application to use Kakao’
   - [Configure Logto](#configure-logto)
     - [Config types](#config-types)
       - [clientId](#clientid)
-      - [clientSeceret](#clientseceret)
+      - [clientSecret](#clientsecret)
 
-## Set up a project in the Kakao Devlopers Console
+## Set up a project in the Kakao Developers Console
 - Visit the [Kakao Developers Console](https://developers.kakao.com/console/app) and sign in with your Kakao account.
 - Click the **Add an application** to create new project or choose exist project.
 
@@ -50,6 +50,6 @@ The Kakao connector provides a succinct way for your application to use Kakao’
 `clientId` is `REST API key` of your project.
 (You can find it from `summary` of your project from Kakao developers console.)
 
-#### clientSeceret
+#### clientSecret
 `clientSecret` is `Secret Code` of your project.
 (Please check [Security Setting (Optional)](#security-setting-optional))

--- a/packages/connectors/connector-mailgun/src/types.ts
+++ b/packages/connectors/connector-mailgun/src/types.ts
@@ -23,7 +23,7 @@ type TemplateEmailConfig = CommonEmailConfig & {
   variables?: Record<string, unknown>;
 };
 
-/** Config object fot a specific template type. */
+/** Config object for a specific template type. */
 export type DeliveryConfig = RawEmailConfig | TemplateEmailConfig;
 
 const templateConfigGuard = z.union([

--- a/packages/connectors/connector-naver/README.md
+++ b/packages/connectors/connector-naver/README.md
@@ -9,7 +9,7 @@ Currently `Naver Developers` site only supports Korean. Please consider use a tr
 - For the production, you have to get review from Naver team. 
 Otherwise, only registered users can sign in.
   - You can add a tester from `맴버관리(Member Manage)` menu.
-- To get a review, please check `애플리케이션 개발 상태(Application Devlopment Status)` 
+- To get a review, please check `애플리케이션 개발 상태(Application Development Status)`
 from `API 설정(API Setting)` from your application project setting.
 
 
@@ -23,7 +23,7 @@ from `API 설정(API Setting)` from your application project setting.
 
 ### API Usage (사용 API)
 - Choose `네이버 로그인(Naver Login)` for `사용 API(API Usage)`
-- Check `이메일 주소(Email Address), 별명(Nickname), 프로필 사진(Profile Image)` as `필수(Neccessary)` from `권한(Role)` (You can check `추가(Add)` as optional these options, but you cannot get the information from the user.)
+- Check `이메일 주소(Email Address), 별명(Nickname), 프로필 사진(Profile Image)` as `필수(Necessary)` from `권한(Role)` (You can check `추가(Add)` as optional these options, but you cannot get the information from the user.)
 
 ### Sign in Open API Service Environment (로그인 오픈 API 서비스 환경)
 - For `로그인 오픈 API 서비스 환경(Sign in Open API Service Environment)`, add two environment `PC웹(PC Web)` and `모바일웹(Mobile Web)`.

--- a/packages/connectors/connector-saml/README.md
+++ b/packages/connectors/connector-saml/README.md
@@ -142,4 +142,4 @@ Logto also provide a `Profile Mapping` field that users can customize the mappin
 ## Reference
 
 - [Profiles for the OASIS Security Assertion Markup Language (SAML) V2.0](http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf)
-- [samlify - Highly configuarable Node.js SAML 2.0 library for Single Sign On](https://github.com/tngan/samlify)
+- [samlify - Highly configurable Node.js SAML 2.0 library for Single Sign On](https://github.com/tngan/samlify)

--- a/packages/console/CHANGELOG.md
+++ b/packages/console/CHANGELOG.md
@@ -1342,7 +1342,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **console:** chagne user added modal button to done ([#1438](https://github.com/logto-io/logto/issues/1438)) ([ec82507](https://github.com/logto-io/logto/commit/ec82507ca1107154676599afe16491e382a1d524))
+- **console:** change user added modal button to done ([#1438](https://github.com/logto-io/logto/issues/1438)) ([ec82507](https://github.com/logto-io/logto/commit/ec82507ca1107154676599afe16491e382a1d524))
 - **console:** dashboard chart yaxios width ([#1435](https://github.com/logto-io/logto/issues/1435)) ([b26fb0c](https://github.com/logto-io/logto/commit/b26fb0c0c32e7bf2e361acd5e71cf20740bba25b))
 - **console:** fix typo for variant ([#1423](https://github.com/logto-io/logto/issues/1423)) ([f6be19e](https://github.com/logto-io/logto/commit/f6be19e1e321eafd5672b88c6e7f54976032d673))
 - **console:** use icon button in copytoclipboard ([#1440](https://github.com/logto-io/logto/issues/1440)) ([f8a9743](https://github.com/logto-io/logto/commit/f8a9743b2ea978fa2802ac8da4f51f7801d3a87a))
@@ -1356,7 +1356,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **console:** dashbaord chart grid color ([#1417](https://github.com/logto-io/logto/issues/1417)) ([1d5f69d](https://github.com/logto-io/logto/commit/1d5f69db127a939f4c893f27230a96f6acb67f6e))
+- **console:** dashboard chart grid color ([#1417](https://github.com/logto-io/logto/issues/1417)) ([1d5f69d](https://github.com/logto-io/logto/commit/1d5f69db127a939f4c893f27230a96f6acb67f6e))
 - **console:** leave page button should be primary on unsaved changes alert modal ([#1421](https://github.com/logto-io/logto/issues/1421)) ([be004fa](https://github.com/logto-io/logto/commit/be004fa4dab3c61b8396194c7604641ab2d82aad))
 
 ## [1.0.0-alpha.0](https://github.com/logto-io/logto/compare/v0.1.2-alpha.5...v1.0.0-alpha.0) (2022-07-04)
@@ -1413,7 +1413,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **console:** add app icon and api icon ([#830](https://github.com/logto-io/logto/issues/830)) ([373d349](https://github.com/logto-io/logto/commit/373d349db73be01fdbd653c917f7cf9f3817d4d5))
 - **console:** add application column in user management ([#728](https://github.com/logto-io/logto/issues/728)) ([a035587](https://github.com/logto-io/logto/commit/a0355872c65bc0da27e57e25568fbe5dcc5b671b))
 - **console:** add column lastSignIn in user management ([#679](https://github.com/logto-io/logto/issues/679)) ([a0b4b98](https://github.com/logto-io/logto/commit/a0b4b98c35ff08c2df0863e4bc2110386fc54aee))
-- **console:** add comopnent alert ([#706](https://github.com/logto-io/logto/issues/706)) ([60920c2](https://github.com/logto-io/logto/commit/60920c28dd0ab5481138264a0961d674abaa613b))
+- **console:** add component alert ([#706](https://github.com/logto-io/logto/issues/706)) ([60920c2](https://github.com/logto-io/logto/commit/60920c28dd0ab5481138264a0961d674abaa613b))
 - **console:** add date picker in dashboard ([#1085](https://github.com/logto-io/logto/issues/1085)) ([5a073ce](https://github.com/logto-io/logto/commit/5a073ceb60932cb4f998bf5f6e80792e63c6552d))
 - **console:** add details summary component in guides ([693c4f0](https://github.com/logto-io/logto/commit/693c4f0422eb312190f2c7b0673e3ceaa8c41213))
 - **console:** add drawer animation ([#760](https://github.com/logto-io/logto/issues/760)) ([dd8b767](https://github.com/logto-io/logto/commit/dd8b7671306b4f712eb56cee339cc38a0c7061fc))
@@ -1422,7 +1422,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **console:** add mobile web tab in preview ([#1214](https://github.com/logto-io/logto/issues/1214)) ([9b6fd4c](https://github.com/logto-io/logto/commit/9b6fd4c417f2ee53375e436c839b711c86403d58))
 - **console:** add page loading skeleton to data table and detail pages ([9b8658d](https://github.com/logto-io/logto/commit/9b8658d9c1d0b916ac4bd00e0355018f3dafb864))
 - **console:** add placeholders ([#1277](https://github.com/logto-io/logto/issues/1277)) ([c26ca08](https://github.com/logto-io/logto/commit/c26ca08fb1109a2f3dae53bc8a1db5d8d7f6f47f))
-- **console:** add prevew in guide modal ([#839](https://github.com/logto-io/logto/issues/839)) ([002f839](https://github.com/logto-io/logto/commit/002f839e31c26733adb8865e6ed3be5464865799))
+- **console:** add preview in guide modal ([#839](https://github.com/logto-io/logto/issues/839)) ([002f839](https://github.com/logto-io/logto/commit/002f839e31c26733adb8865e6ed3be5464865799))
 - **console:** add user dropdown and sign out button ([5a09e7d](https://github.com/logto-io/logto/commit/5a09e7d6aa0d74215b299ef95b94bc715392cb77))
 - **console:** audit log filters ([#1004](https://github.com/logto-io/logto/issues/1004)) ([a0d562f](https://github.com/logto-io/logto/commit/a0d562f7f24e10481c269b761c9a2c152affd50e))
 - **console:** audit log table ([#1000](https://github.com/logto-io/logto/issues/1000)) ([fdd12de](https://github.com/logto-io/logto/commit/fdd12de1cf39c36dd65dd9365ad343478718d112))
@@ -1525,14 +1525,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **console:** connector details save changes footer ([#736](https://github.com/logto-io/logto/issues/736)) ([2d9b708](https://github.com/logto-io/logto/commit/2d9b7088a6f7f126b48eb2f395c255b7254b4b34))
 - **console:** connector guide ([#990](https://github.com/logto-io/logto/issues/990)) ([3c37739](https://github.com/logto-io/logto/commit/3c37739107794466a30c44163743915d489bb3ae))
 - **console:** connector guide setup content should scroll in the whole container ([#1314](https://github.com/logto-io/logto/issues/1314)) ([05399b5](https://github.com/logto-io/logto/commit/05399b5e594c0af591eadeb017af073cc9b9edcc))
-- **console:** connector name in user detials ([#1147](https://github.com/logto-io/logto/issues/1147)) ([94084a4](https://github.com/logto-io/logto/commit/94084a49e77d964e4f9c230f88e3aa7d5e12179a))
+- **console:** connector name in user details ([#1147](https://github.com/logto-io/logto/issues/1147)) ([94084a4](https://github.com/logto-io/logto/commit/94084a49e77d964e4f9c230f88e3aa7d5e12179a))
 - **console:** connector row clickable ([#1108](https://github.com/logto-io/logto/issues/1108)) ([2a4a61d](https://github.com/logto-io/logto/commit/2a4a61deabc827353ac7471565f25bb52d07fc1c))
 - **console:** connector sender test loading state ([#1290](https://github.com/logto-io/logto/issues/1290)) ([7d47433](https://github.com/logto-io/logto/commit/7d47433cca2a8f6d3d11fb9a98c1b7c67d9710b2))
 - **console:** contact us icons ([#1181](https://github.com/logto-io/logto/issues/1181)) ([e39704a](https://github.com/logto-io/logto/commit/e39704a8fa280201682f0e9e23d7b3f9d14e7d76))
 - **console:** create connector form alignment ([#1220](https://github.com/logto-io/logto/issues/1220)) ([ebfab1d](https://github.com/logto-io/logto/commit/ebfab1d222be34a335478715c3cec38393e0af21))
 - **console:** dashboard chart style ([#1177](https://github.com/logto-io/logto/issues/1177)) ([cf47044](https://github.com/logto-io/logto/commit/cf470446e4458e748bbf6384adb96d69805a1991)), closes [#1178](https://github.com/logto-io/logto/issues/1178)
 - **console:** date picker input height ([#1171](https://github.com/logto-io/logto/issues/1171)) ([6ca1395](https://github.com/logto-io/logto/commit/6ca1395b8bf6e6b58c539b23fca2167ee3d47746))
-- **console:** details page should not be shrinked ([#1338](https://github.com/logto-io/logto/issues/1338)) ([d73663a](https://github.com/logto-io/logto/commit/d73663af27a7a0f63d18e0015817aa5b5347cad9))
+- **console:** details page should not be shrunk ([#1338](https://github.com/logto-io/logto/issues/1338)) ([d73663a](https://github.com/logto-io/logto/commit/d73663af27a7a0f63d18e0015817aa5b5347cad9))
 - **console:** display dark mode color setting only when dark mode is enabled ([#1027](https://github.com/logto-io/logto/issues/1027)) ([a506dc5](https://github.com/logto-io/logto/commit/a506dc5511e19bbf948ba96cab23489e2c55bbc3))
 - **console:** display default avatar when the avatar is empty ([#1191](https://github.com/logto-io/logto/issues/1191)) ([71ed416](https://github.com/logto-io/logto/commit/71ed416bde2c03bc6808d0857f4e59725ad0015d))
 - **console:** dropdown max height ([#1155](https://github.com/logto-io/logto/issues/1155)) ([402d19d](https://github.com/logto-io/logto/commit/402d19d5608fe695ae8c4f60172563b8f51511e1))
@@ -1553,7 +1553,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **console:** hide url input on terms of use disabled ([#1270](https://github.com/logto-io/logto/issues/1270)) ([1e6ad9f](https://github.com/logto-io/logto/commit/1e6ad9f15f0ce3de577033e1b59c2b25f460adec))
 - **console:** hide user column ([#1296](https://github.com/logto-io/logto/issues/1296)) ([9b19b0e](https://github.com/logto-io/logto/commit/9b19b0e970b0c54d26b1ad59fe242672f6573f86))
 - **console:** icon colors on the action menu ([#1179](https://github.com/logto-io/logto/issues/1179)) ([d71c18c](https://github.com/logto-io/logto/commit/d71c18c83c4065b28213ca93ae514a59879192de))
-- **console:** icons in item preview should not be shrinked ([#1234](https://github.com/logto-io/logto/issues/1234)) ([2d66302](https://github.com/logto-io/logto/commit/2d663025ecbd08dc39878e2fd32cfb08b92e9b3a))
+- **console:** icons in item preview should not be shrunk ([#1234](https://github.com/logto-io/logto/issues/1234)) ([2d66302](https://github.com/logto-io/logto/commit/2d663025ecbd08dc39878e2fd32cfb08b92e9b3a))
 - **console:** improve horizontal scrollbar thumb styles ([818b1d7](https://github.com/logto-io/logto/commit/818b1d7cc78fb89060b23e3578b30fd20b6f2393))
 - **console:** improve swr error handling to avoid app crash ([da77a1d](https://github.com/logto-io/logto/commit/da77a1d1b5c49f2e806bf0d5f27e326e081f1735))
 - **console:** item preview alignment ([#1159](https://github.com/logto-io/logto/issues/1159)) ([5c43da2](https://github.com/logto-io/logto/commit/5c43da2201db8dbb4b782563fd37cad655326cad))

--- a/packages/console/scripts/generate-jwt-customizer-type-definition.ts
+++ b/packages/console/scripts/generate-jwt-customizer-type-definition.ts
@@ -35,7 +35,7 @@ const inferTsDefinitionFromZod = (zodSchema: ZodTypeAny, identifier: string): st
    * The second argument is the root type identifier for the schema.
    * Here we use 'Record<string, unknown>' as the root type identifier. So all the Json objects will be inferred as Record<string, unknown>.
    * This is a limitation of zod-to-ts. We can't infer the exact type of the Json objects.
-   * This solution is hacky but it works for now. The impact is it will always define the type identifer as Record<string, unknown>.
+   * This solution is hacky but it works for now. The impact is it will always define the type identifier as Record<string, unknown>.
    */
   const { node } = zodToTs(zodSchema, 'Record<string, unknown>', { nativeEnums: 'union' });
   const typeDefinition = printNode(node);

--- a/packages/console/src/assets/docs/guides/native-ios-swift/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-ios-swift/README.mdx
@@ -114,7 +114,7 @@ For example, in a SwiftUI app:
               }")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // error occured during sign in
+              // error occurred during sign in
             } catch {
               // other errors
             }

--- a/packages/console/src/assets/docs/guides/spa-webflow/README.mdx
+++ b/packages/console/src/assets/docs/guides/spa-webflow/README.mdx
@@ -9,7 +9,7 @@ import Step from '@/mdx-components/Step';
 
 <Step title="Preparation">
 
-### Prerequisits:
+### Prerequisites:
 
 1. Integrating Logto with Webflow requires the "Custom code" feature of Webflow, which requires at least the "Basic" plan.
 2. A Webflow site, either use an existing site or create a new one.

--- a/packages/console/src/assets/docs/guides/web-gpt-plugin/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-gpt-plugin/README.mdx
@@ -23,7 +23,7 @@ Go through the [Chat Plugins introduction](https://platform.openai.com/docs/plug
 
 <Step title="Fill out the redirect URI">
 
-Once your plugin is registered, replace the `[your-plugin-id]` below with the acutal ID. For example, if your plugin ID is `foo123`, the value should be `https://chat.openai.com/aip/foo123/oauth/callback`.
+Once your plugin is registered, replace the `[your-plugin-id]` below with the actual ID. For example, if your plugin ID is `foo123`, the value should be `https://chat.openai.com/aip/foo123/oauth/callback`.
 
 <UriInputField name="redirectUris" defaultValue="https://chat.openai.com/aip/[your-plugin-id]/oauth/callback" />
 

--- a/packages/console/src/assets/docs/guides/web-wordpress/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-wordpress/README.mdx
@@ -17,7 +17,7 @@ Follow the official [Wordpress installation guide](https://wordpress.org/support
 
 <Step title="Install the plugin">
 
-We will use the [OpenID Connect Generic](https://wordpress.org/plugins/generic-openid-connect/) plugin to integrate Logto via OIDC protocal into your Wordpress website.
+We will use the [OpenID Connect Generic](https://wordpress.org/plugins/generic-openid-connect/) plugin to integrate Logto via OIDC protocol into your WordPress website.
 
 1. Log in to your WordPress site.
 2. Navigate to "Plugins" and click "Add New".

--- a/packages/console/src/components/FeatureTag/index.tsx
+++ b/packages/console/src/components/FeatureTag/index.tsx
@@ -113,7 +113,7 @@ type CombinedAddOnAndFeatureTagProps = {
   readonly className?: string;
   /** The minimum plan required to use the feature. */
   readonly paywall?: PaywallPlanId;
-  /** Customize the add-on lable: currently only used by bundled add-ons  */
+  /** Customize the add-on label: currently only used by bundled add-ons  */
   readonly addOnLabel?: (typeof addOnLabels)[keyof typeof addOnLabels];
 };
 

--- a/packages/console/src/components/Markdown/index.tsx
+++ b/packages/console/src/components/Markdown/index.tsx
@@ -33,7 +33,7 @@ function Markdown({ className, children }: Props) {
     };
 
     const initialKebabCaseString = text
-      // Remove all symbols and punctuations except for dash and underscore. https://javascript.info/regexp-unicode
+      // Remove all symbols and punctuation except for dash and underscore. https://javascript.info/regexp-unicode
       .replaceAll(/\p{S}|\p{Pi}|\p{Pf}|\p{Ps}|\p{Pe}|\p{Po}/gu, '')
       .replaceAll(/\s+/g, '-')
       .toLowerCase();

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -31,7 +31,7 @@
 
   In the previous implementation, Logto did not normalize the user's phone number during the user sign-up process. Both 61021345678 and 61212345678 were considered as valid phone numbers, and we do not normalize them before storing them in the database. This could lead to confusion when users try to sign-in with their phone numbers, as they may not remember the exact format they used during sign-up. Users may also end up with different accounts for the same phone number, depending on how they entered it during sign-up.
 
-  To address this issue, especially for legacy users, we have added a new enhenced user lookup by phone with either format (with or without leading '0') to the user sign-in process. This means that users can now sign-in with either format of their phone number, and Logto will try to match it with the one stored in the database, even if they might have different formats. This will help to reduce confusion and improve the user experience when logging in with phone numbers.
+  To address this issue, especially for legacy users, we have added a new enhanced user lookup by phone with either format (with or without leading '0') to the user sign-in process. This means that users can now sign-in with either format of their phone number, and Logto will try to match it with the one stored in the database, even if they might have different formats. This will help to reduce confusion and improve the user experience when logging in with phone numbers.
 
   For example:
 
@@ -156,7 +156,7 @@
   This prevents the browser and CDN from caching the `index.html` file for non-existing paths in `/assets`, which can lead to confusion and unexpected behavior.
   Since the `/assets` path is used only for static assets, it is safe and improves the user experience.
 
-- 7dbcedaa1: move password encyption to separate worker thread
+- 7dbcedaa1: move password encryption to separate worker thread
 
   This update refactors the password encryption process by moving it to a separate Node.js worker thread. The Argon2i encryption method, known for its resource-intensive and time-consuming nature, is now handled in a dedicated worker. This change aims to prevent the encryption process from blocking other requests, thereby improving the overall performance and responsiveness of the application.
 
@@ -334,7 +334,7 @@
 
 ### Minor Changes
 
-- 1c7bdf9ba: add legacy password type supporting custom hasing function, credits @fre2d0m
+- 1c7bdf9ba: add legacy password type supporting custom hashing function, credits @fre2d0m
 
   You can now set the type of `password_encryption_method` to `legacy`, and store info with a JSON string format (containing a hash algorithm, arguments, and an encrypted password) in the `password_encrypted` field. By doing this, you can use any hash algorithm supported by Node.js, this is useful when migrating from other password hash algorithms, especially for the ones that include salt.
 
@@ -577,7 +577,7 @@
 
 - f1b1d9e95: new MFA prompt policy
 
-  You can now cutomize the MFA prompt policy in the Console.
+  You can now customize the MFA prompt policy in the Console.
 
   First, choose if you want to enable **Require MFA**:
 
@@ -972,7 +972,7 @@
 
   In `POST /users`, the `passwordAlgorithm` field now accepts `Argon2d` and `Argon2id`.
 
-  Users with those algorithms will be migrated to `Argon2i` upon succussful sign in.
+  Users with those algorithms will be migrated to `Argon2i` upon successful sign in.
 
 - 510f681fa: use tsup for building
 
@@ -1518,7 +1518,7 @@
 
 - 532454b92: support form post callback for social connectors
 
-  Add the `POST /callback/:connectorId` endpoint to handle the form post callback for social connectors. This usefull for the connectors that require a form post callback to complete the authentication process, such as Apple.
+  Add the `POST /callback/:connectorId` endpoint to handle the form post callback for social connectors. This is useful for the connectors that require a form post callback to complete the authentication process, such as Apple.
 
 ### Patch Changes
 
@@ -2847,7 +2847,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **core:** cookie keys configuration ([#902](https://github.com/logto-io/logto/issues/902)) ([17c63cd](https://github.com/logto-io/logto/commit/17c63cd2d9fe5f3f66fe2404a7358f0d8524e667))
 - **core:** dau curve contains 0 count points ([#1105](https://github.com/logto-io/logto/issues/1105)) ([75ac874](https://github.com/logto-io/logto/commit/75ac874a2d02e308d6a63f4925e3f9b2c3377b8d))
 - **core:** disable introspection feature ([#886](https://github.com/logto-io/logto/issues/886)) ([b2ac2c1](https://github.com/logto-io/logto/commit/b2ac2c14eead0fba45dec90115f75dd2074e04ee))
-- **core:** empty path sould redirect to the console page ([#915](https://github.com/logto-io/logto/issues/915)) ([207c404](https://github.com/logto-io/logto/commit/207c404aebd062f2f46742748ed08c5d97368dbc))
+- **core:** empty path should redirect to the console page ([#915](https://github.com/logto-io/logto/issues/915)) ([207c404](https://github.com/logto-io/logto/commit/207c404aebd062f2f46742748ed08c5d97368dbc))
 - **core:** expose connector and metadata from sendPasscode ([#806](https://github.com/logto-io/logto/issues/806)) ([0ea5513](https://github.com/logto-io/logto/commit/0ea55134a92252a00f6b3532cdde71ae96979452))
 - **core:** fix connectors' initialization ([c6f2546](https://github.com/logto-io/logto/commit/c6f2546126ec48da0ef28f939a062c844c03b2b7))
 - **core:** get /dashboard/users/new ([#940](https://github.com/logto-io/logto/issues/940)) ([45a9777](https://github.com/logto-io/logto/commit/45a977790eca01b212f51047d5636ff882873dd8))

--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -142,7 +142,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
   // @ts-expect-error: helmet typings has lots of {A?: T, B?: never} | {A?: never, B?: T} options definitions. Optional settings type can not inferred correctly.
   const consoleSecurityHeaderSettings: HelmetOptions = {
     ...basicSecurityHeaderSettings,
-    // Guarded by CSP header bellow
+    // Guarded by CSP header below
     frameguard: false,
     contentSecurityPolicy: {
       useDefaults: true,

--- a/packages/core/src/middleware/koa-token-usage-guard.ts
+++ b/packages/core/src/middleware/koa-token-usage-guard.ts
@@ -68,7 +68,7 @@ export default function koaTokenUsageGuard<StateT, ContextT, ResponseBodyT>(
         throw error;
       }
 
-      // Incase of any unexpected error, track it to App Insights and continue the request.
+      // In case of any unexpected error, track it to App Insights and continue the request.
       // Should not block the end-user's request for any unexpected error.
       void appInsights.trackException(error, buildAppInsightsTelemetry(ctx));
     }

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -66,7 +66,7 @@ export const getExtraTokenClaimsForOrganizationApiResource = async (
 };
 
 /**
- * The field `extra` in the access token will be overidden by the return value of `extraTokenClaims` function,
+ * The field `extra` in the access token will be overridden by the return value of `extraTokenClaims` function,
  * previously in token exchange grant, this field is used to save `act` data temporarily,
  * here we validate the data and return them again to prevent data loss.
  */

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -151,7 +151,7 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
       return users[0] ?? null;
     }
 
-    // Incase user has created two different accounts with the same phone number, one with leading '0' and one without.
+    // In case a user has created two different accounts with the same phone number, one with leading '0' and one without.
     // If more than one user is found, return the user with the exact match.
     // Otherwise, return the first found user, which should be the be the latest one.
     return users.find((user) => user.primaryPhone === phone) ?? users[0] ?? null;

--- a/packages/core/src/routes/applications/application-protected-app-metadata.openapi.json
+++ b/packages/core/src/routes/applications/application-protected-app-metadata.openapi.json
@@ -9,7 +9,7 @@
             "description": "An array of the application custom domains."
           },
           "400": {
-            "description": "Faild to sync the domain info from remote provider."
+            "description": "Failed to sync the domain info from remote provider."
           }
         }
       },
@@ -37,7 +37,7 @@
             "description": "The domain already exists."
           },
           "422": {
-            "description": "Exeeded the maximum number of domains allowed or the domain is invalid."
+            "description": "Exceeded the maximum number of domains allowed or the domain is invalid."
           }
         }
       }

--- a/packages/core/src/routes/authn.ts
+++ b/packages/core/src/routes/authn.ts
@@ -108,7 +108,7 @@ export default function authnRoutes<T extends AnonymousRouter>(
   /**
    * Standard SAML social connector's assertion consumer service endpoint
    * @deprecated
-   * Will be replaced by the SSO SAML assertion consumer service endpoint bellow.
+   * Will be replaced by the SSO SAML assertion consumer service endpoint below.
    */
   router.post(
     '/authn/saml/:connectorId',

--- a/packages/core/src/routes/interaction/actions/submit-interaction.mfa.test.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.mfa.test.ts
@@ -90,7 +90,7 @@ describe('submit action', () => {
     id: 'foo',
     name: 'foo_social',
     avatar: 'avatar',
-    email: 'email@socail.com',
+    email: 'email@social.com',
     phone: '123123',
   };
 

--- a/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
@@ -100,7 +100,7 @@ describe('submit action', () => {
     id: 'foo',
     name: 'foo_social',
     avatar: 'avatar',
-    email: 'email@socail.com',
+    email: 'email@social.com',
     phone: '123123',
   };
 

--- a/packages/core/src/routes/interaction/verifications/mfa-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-verification.ts
@@ -82,7 +82,7 @@ export const verifyMfa = async (
       return verification.codes.some((code) => !code.usedAt);
     })
     .reduce<MfaVerification[]>((factors, verification) => {
-      // Ingnore duplicated verification
+      // Ignore duplicated verification
       if (factors.some(({ type }) => type === verification.type)) {
         return factors;
       }

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -180,11 +180,10 @@ export const buildOperationId = (method: OpenAPIV3.HttpMethods, path: string) =>
     return;
   }
 
-  const splitted = namespacePrefixes
+  const parts = namespacePrefixes
     .reduce((accumulator, prefix) => accumulator.replace(prefix + '/', prefix + '-'), path)
     .split('/');
-
-  const lastItem = splitted.at(-1);
+  const lastItem = parts.at(-1);
 
   if (!lastItem) {
     throwIfNeeded(method, path);
@@ -192,7 +191,7 @@ export const buildOperationId = (method: OpenAPIV3.HttpMethods, path: string) =>
   }
 
   const isForSingleItem = isPathParameter(lastItem);
-  const items = chunk(splitted.slice(1, isForSingleItem ? undefined : -1), 2);
+  const items = chunk(parts.slice(1, isForSingleItem ? undefined : -1), 2);
 
   // Check if all items have the pattern of `[name, parameter]`
   if (

--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -206,7 +206,7 @@ export const getRawUserInfoResponse = async (accessToken: string, userinfoEndpoi
 };
 
 /**
- * Get the user info from the userinfo endpoint incase id token does not contain sufficient user claims.
+ * Get the user info from the userinfo endpoint in case id token does not contain sufficient user claims.
  */
 export const getUserInfo = async (accessToken: string, userinfoEndpoint: string) => {
   try {

--- a/packages/core/src/utils/jwks.ts
+++ b/packages/core/src/utils/jwks.ts
@@ -1,5 +1,5 @@
 /**
- * Theses codes comes from [node-oidc-provider](https://github.com/panva/node-oidc-provider):
+ * These codes come from [node-oidc-provider](https://github.com/panva/node-oidc-provider):
  * - [initialize_keystore.js](https://github.com/panva/node-oidc-provider/blob/9da61e9c9dc6152cd1140d42ea06abe1d812c286/lib/helpers/initialize_keystore.js#L13-L36)
  */
 

--- a/packages/experience/CHANGELOG.md
+++ b/packages/experience/CHANGELOG.md
@@ -220,7 +220,7 @@
 
 - f1b1d9e95: new MFA prompt policy
 
-  You can now cutomize the MFA prompt policy in the Console.
+  You can now customize the MFA prompt policy in the Console.
 
   First, choose if you want to enable **Require MFA**:
 
@@ -1025,7 +1025,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **ui:** app notification ([#999](https://github.com/logto-io/logto/issues/999)) ([f4e380f](https://github.com/logto-io/logto/commit/f4e380f0b1b815314b24cec1c9013d9f3bb806a7))
 - **ui:** display error message on social callback page ([#1097](https://github.com/logto-io/logto/issues/1097)) ([f3b8678](https://github.com/logto-io/logto/commit/f3b8678a8c5e938276208c222242c3fedf4d397a))
 - **ui:** implement preview mode ([#852](https://github.com/logto-io/logto/issues/852)) ([ef19fb3](https://github.com/logto-io/logto/commit/ef19fb3d27a84509613b1f1d47819c06e9a6e9d1))
-- **ui:** init destop styling foundation ([#787](https://github.com/logto-io/logto/issues/787)) ([5c02ec3](https://github.com/logto-io/logto/commit/5c02ec3bdae162bd83d26c56f7ae34ee6e505ca2))
+- **ui:** init desktop styling foundation ([#787](https://github.com/logto-io/logto/issues/787)) ([5c02ec3](https://github.com/logto-io/logto/commit/5c02ec3bdae162bd83d26c56f7ae34ee6e505ca2))
 - **ui:** not found page ([#691](https://github.com/logto-io/logto/issues/691)) ([731ff1c](https://github.com/logto-io/logto/commit/731ff1cbdca76104845dcf3d1223953ce8e5af93))
 
 ### Bug Fixes
@@ -1035,7 +1035,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - revert "chore(deps): update parcel monorepo to v2.6.0" ([877bbc0](https://github.com/logto-io/logto/commit/877bbc0d2c5c0559a3fc9a8e801a13ebff2292a6))
 - **ui:** add body background color ([#831](https://github.com/logto-io/logto/issues/831)) ([be8b862](https://github.com/logto-io/logto/commit/be8b8628ba345bd8f8832b2123a43e70c236406d))
 - **ui:** add default success true for no response api ([#842](https://github.com/logto-io/logto/issues/842)) ([88600c0](https://github.com/logto-io/logto/commit/88600c012c892c969f1e5df7ec5f46874513a058))
-- **ui:** add i18n formater for zh-CN list ([#1009](https://github.com/logto-io/logto/issues/1009)) ([ca5c8aa](https://github.com/logto-io/logto/commit/ca5c8aaec1db7ffc330f50fcdc14400e06ad6f54))
+- **ui:** add i18n formatter for zh-CN list ([#1009](https://github.com/logto-io/logto/issues/1009)) ([ca5c8aa](https://github.com/logto-io/logto/commit/ca5c8aaec1db7ffc330f50fcdc14400e06ad6f54))
 - **ui:** catch request exceptions with no response body ([#790](https://github.com/logto-io/logto/issues/790)) ([48de9c0](https://github.com/logto-io/logto/commit/48de9c072bb060f3e5aeb785d7a765a66a0912fe))
 - **ui:** fix callback link params for apple ([#985](https://github.com/logto-io/logto/issues/985)) ([362c3a6](https://github.com/logto-io/logto/commit/362c3a6e6ed3cab24a85f9e268509d31430609e4))
 - **ui:** fix ci fail ([#708](https://github.com/logto-io/logto/issues/708)) ([da49812](https://github.com/logto-io/logto/commit/da4981216452ee11cf91c8f52a1d50ef18f9a37f))

--- a/packages/experience/src/containers/DevelopmentTenantNotification/index.tsx
+++ b/packages/experience/src/containers/DevelopmentTenantNotification/index.tsx
@@ -24,7 +24,7 @@ const buildPermanentVisibleStyles = (styles: Record<string, string>) => ({
 });
 
 /**
- * Apply inline styles with '!important' to a DOM element to make theses styles become the highest priority.
+ * Apply inline styles with '!important' to a DOM element to make these styles become the highest priority.
  *
  * It's useful when we want to ensure these styles won't be override via the user's custom CSS config.
  */

--- a/packages/experience/src/pages/RegisterPassword/index.tsx
+++ b/packages/experience/src/pages/RegisterPassword/index.tsx
@@ -38,7 +38,7 @@ const RegisterPassword = () => {
 
   const errorHandlers: ErrorHandlers = useMemo(
     () => ({
-      // Incase previous page submitted username has been taken
+      // In case previous page submitted username has been taken
       'user.username_already_in_use': async (error) => {
         await show({ type: 'alert', ModalContent: error.message, cancelText: 'action.got_it' });
         navigate(-1);

--- a/packages/integration-tests/CHANGELOG.md
+++ b/packages/integration-tests/CHANGELOG.md
@@ -63,7 +63,7 @@
 
 - f1b1d9e95: new MFA prompt policy
 
-  You can now cutomize the MFA prompt policy in the Console.
+  You can now customize the MFA prompt policy in the Console.
 
   First, choose if you want to enable **Require MFA**:
 

--- a/packages/schemas/alterations/1.18.0-1718865814-add-subject-tokens.ts
+++ b/packages/schemas/alterations/1.18.0-1718865814-add-subject-tokens.ts
@@ -17,7 +17,7 @@ const alteration: AlterationScript = {
         user_id varchar(21) not null
           references users (id) on update cascade on delete cascade,
         created_at timestamptz not null default(now()),
-        creator_id varchar(32) not null, /* It is intented to not reference to user or application table */
+        creator_id varchar(32) not null, /* It is intended to not reference to user or application table */
         primary key (id)
       );
 

--- a/packages/schemas/src/types/verification-records/index.ts
+++ b/packages/schemas/src/types/verification-records/index.ts
@@ -1,6 +1,6 @@
 /**
  * This file defines the data types and guards for verification records in Logto.
- * We keep these definitions in @logto/schemas to ensure it can be shared accross different packages.
+ * We keep these definitions in @logto/schemas to ensure it can be shared across different packages.
  *
  * Check {@link @logto/core/src/routes/experience/classes/verifications} for the implementation of verification records.
  */

--- a/packages/schemas/tables/subject_tokens.sql
+++ b/packages/schemas/tables/subject_tokens.sql
@@ -8,7 +8,7 @@ create table subject_tokens (
   user_id varchar(21) not null
     references users (id) on update cascade on delete cascade,
   created_at timestamptz not null default(now()),
-  /* It is intented to not reference to user or application table, it can be userId or applicationId, for audit only */
+  /* It is intended to not reference to user or application table, it can be userId or applicationId, for audit only */
   creator_id varchar(32) not null,
   primary key (id)
 );

--- a/packages/shared/src/utils/phone.ts
+++ b/packages/shared/src/utils/phone.ts
@@ -128,7 +128,7 @@ export class PhoneNumberParser {
    *
    * Both formats should be considered the same phone number.
    *
-   * We use this format to find the legacy phone number in the database incase the user registered the phone number with leading `0`.
+   * We use this format to find the legacy phone number in the database in case the user registered the phone number with leading `0`.
    */
   get internationalNumberWithLeadingZero() {
     if (!this.#isValid || !this.nationalNumber || !this.countryCode) {

--- a/packages/tunnel/src/commands/deploy/utils.ts
+++ b/packages/tunnel/src/commands/deploy/utils.ts
@@ -203,8 +203,8 @@ const throwRequestError = async (response: Response) => {
 };
 
 const getTenantIdFromEndpointUri = (endpoint: URL) => {
-  const splitted = endpoint.hostname.split('.');
-  return splitted.length > 2 ? splitted[0] : 'default';
+  const parts = endpoint.hostname.split('.');
+  return parts.length > 2 ? parts[0] : 'default';
 };
 
 const getManagementApiResourceFromEndpointUri = (endpoint: URL) => {


### PR DESCRIPTION
## Summary
- fix lots of spelling errors in docs, changelogs and comments
- keep semantics the same

## Testing
- `pnpm ci:lint` *(fails: connector packages lint issues)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models tests)*

------
https://chatgpt.com/codex/tasks/task_e_684eb44e0b70832f805f2fdc1686df1a