### PR TITLE
Ensure connector deletion uses transaction

### DIFF
--- a/docs-ref/connector-transactions.md
+++ b/docs-ref/connector-transactions.md
@@ -1,0 +1,13 @@
+# Connector Route Transactions
+
+**File paths**
+- `packages/core/src/routes/connector/index.ts`
+- `packages/core/src/routes/connector/index.delete.test.ts`
+
+**Key changes**
+- Connector removal now runs inside `queries.pool.transaction()`.
+- Sign-in experience cleanup is executed within the same transaction.
+- Added a test verifying rollback when the cleanup step fails.
+
+**New dependencies / environment variables**
+- None.


### PR DESCRIPTION
## Summary
- make connector deletion transactional
- test rollback when sign-in cleanup fails
- document connector route transactions

## Testing
- `pnpm ci:lint` *(fails: @logto/connector-alipay-web lint issues)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models test:ci failure)*

------
https://chatgpt.com/codex/tasks/task_e_684eb43643b8832f8e8a83446a5c3c89