### PR TITLE
Expose captcha score threshold option

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -28,4 +28,4 @@ Copy the API output and paste it in the [Swagger Editor](https://editor.swagger.
 
 ## CAPTCHA verification
 
-The default score threshold for reCAPTCHA Enterprise is **0.7**. You can override this value via `scoreThreshold` in the CAPTCHA provider configuration.
+The default score threshold for reCAPTCHA Enterprise is **0.7**. You can override this value via `scoreThreshold` in the CAPTCHA provider configuration or set the `CAPTCHA_SCORE_THRESHOLD` environment variable.

--- a/packages/core/src/captcha/index.ts
+++ b/packages/core/src/captcha/index.ts
@@ -1,0 +1,6 @@
+const DEFAULT_THRESHOLD = 0.7;
+
+const envValue = Number.parseFloat(process.env.CAPTCHA_SCORE_THRESHOLD ?? '');
+export const defaultScoreThreshold = Number.isFinite(envValue)
+  ? Math.min(Math.max(envValue, 0), 1)
+  : DEFAULT_THRESHOLD;

--- a/packages/core/src/routes/experience/classes/libraries/captcha-validator.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/captcha-validator.test.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment */
+import { CaptchaType } from '@logto/schemas';
+import ky, { type KyResponse } from 'ky';
+
+// @ts-expect-error -- jest from import.meta
+const { jest } = import.meta;
+
+const envBackup = process.env;
+const log = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  append() {},
+};
+
+const makeResponse = (score: number): KyResponse =>
+  ({
+    json: async () => ({
+      tokenProperties: { valid: true },
+      riskAnalysis: { score },
+    }),
+  }) as unknown as KyResponse;
+
+const post = jest
+  .spyOn(ky, 'post')
+  // @ts-expect-error -- ky typings do not match jest mock
+  .mockResolvedValue(makeResponse(0));
+
+beforeEach(() => {
+  process.env = { ...envBackup };
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('CaptchaValidator threshold', () => {
+  const baseProvider = {
+    id: 'id',
+    tenantId: 'tenant',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    config: {
+      type: CaptchaType.RecaptchaEnterprise,
+      siteKey: 'key',
+      secretKey: 'secret',
+      projectId: 'project',
+    },
+  } as const;
+
+  it('uses default threshold from env', async () => {
+    process.env.CAPTCHA_SCORE_THRESHOLD = '0.6';
+    jest.resetModules();
+    const { CaptchaValidator } = await import('./captcha-validator.js');
+
+    post.mockResolvedValueOnce(makeResponse(0.65));
+
+    const validator = new CaptchaValidator({ ...baseProvider }, log);
+    await expect(validator.verifyCaptcha('token')).resolves.toBe(true);
+  });
+
+  it('fails when score below env threshold', async () => {
+    process.env.CAPTCHA_SCORE_THRESHOLD = '0.9';
+    jest.resetModules();
+    const { CaptchaValidator } = await import('./captcha-validator.js');
+
+    post.mockResolvedValueOnce(makeResponse(0.85));
+
+    const validator = new CaptchaValidator({ ...baseProvider }, log);
+    await expect(validator.verifyCaptcha('token')).resolves.toBe(false);
+  });
+
+  it('provider config overrides env', async () => {
+    process.env.CAPTCHA_SCORE_THRESHOLD = '0.9';
+    jest.resetModules();
+    const { CaptchaValidator } = await import('./captcha-validator.js');
+
+    post.mockResolvedValueOnce(makeResponse(0.81));
+
+    const validator = new CaptchaValidator(
+      {
+        ...baseProvider,
+        config: { ...baseProvider.config, scoreThreshold: 0.8 },
+      },
+      log
+    );
+    await expect(validator.verifyCaptcha('token')).resolves.toBe(true);
+  });
+});
+
+/* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment */

--- a/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call */
 import {
   CaptchaType,
   type CaptchaProvider,
@@ -9,6 +10,7 @@ import { z } from 'zod';
 
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { defaultScoreThreshold } from '#src/captcha/index.js';
 
 function isRecaptchaEnterprise(
   config: CaptchaProvider['config']
@@ -112,7 +114,7 @@ export class CaptchaValidator {
         riskAnalysis: { score },
       } = responseGuard.parse(result);
 
-      const success = valid && score >= (config.scoreThreshold ?? 0.7);
+      const success = valid && score >= (config.scoreThreshold ?? defaultScoreThreshold);
 
       this.log.append({
         success,
@@ -130,3 +132,5 @@ export class CaptchaValidator {
     }
   }
 }
+
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call */


### PR DESCRIPTION
## Summary
- allow overriding captcha score threshold via `CAPTCHA_SCORE_THRESHOLD`
- document the environment variable in `core` README
- respect custom default in captcha validator
- test validator with various thresholds

## Testing
- `pnpm ci:lint` *(fails: connector packages lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models test suite)*

------
https://chatgpt.com/codex/tasks/task_e_684eb423c10c832f97826d3199fe7aaa