### PR TITLE
Remove temporary verification-records checks

### DIFF
--- a/docs-ref/account-center-cleanup.md
+++ b/docs-ref/account-center-cleanup.md
@@ -1,0 +1,16 @@
+# Account Center Cleanup
+
+**File paths**
+- `packages/core/src/middleware/koa-auth/koa-oidc-auth.ts`
+- `packages/core/src/middleware/koa-auth/types.ts`
+- `packages/core/src/routes/account/*`
+- `packages/integration-tests/src/api/my-account.ts`
+- `packages/integration-tests/src/tests/api/account/*`
+
+**Key changes**
+- Removed the temporary `verificationRecordId` header logic from `koa-oidc-auth`.
+- Dropped `identityVerified` checks in account routes.
+- Updated tests and helpers to reflect the new behavior.
+
+**New dependencies / environment variables**
+- None.

--- a/packages/core/src/middleware/koa-auth/constants.ts
+++ b/packages/core/src/middleware/koa-auth/constants.ts
@@ -1,1 +1,0 @@
-export const verificationRecordIdHeader = 'logto-verification-id';

--- a/packages/core/src/middleware/koa-auth/index.ts
+++ b/packages/core/src/middleware/koa-auth/index.ts
@@ -16,7 +16,6 @@ import { type WithAuthContext, type TokenInfo } from './types.js';
 import { extractBearerTokenFromHeaders, getAdminTenantTokenValidationSet } from './utils.js';
 
 export * from './types.js';
-export * from './constants.js';
 
 export const verifyBearerTokenFromRequest = async (
   envSet: EnvSet,

--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.test.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.test.ts
@@ -79,7 +79,6 @@ describe('koaOidcAuth middleware', () => {
       type: 'user',
       id: 'fooUser',
       scopes: new Set(['openid']),
-      identityVerified: false,
       clientId: mockAccessToken.clientId,
     });
   });

--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
@@ -2,51 +2,12 @@ import type { MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
 import RequestError from '#src/errors/RequestError/index.js';
-import {
-  verificationRecordDataGuard,
-  buildVerificationRecord,
-} from '#src/routes/experience/classes/verifications/index.js';
-import type Libraries from '#src/tenants/Libraries.js';
-import type Queries from '#src/tenants/Queries.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { verificationRecordIdHeader } from './constants.js';
 import { type WithAuthContext } from './types.js';
 import { extractBearerTokenFromHeaders } from './utils.js';
 
-/**
- * Builds a verification record by its id.
- * The `userId` is optional and is only used for user sensitive permission verifications.
- */
-const getVerificationRecordResultById = async ({
-  id,
-  queries,
-  libraries,
-  userId,
-}: {
-  id: string;
-  queries: Queries;
-  libraries: Libraries;
-  userId: string;
-}): Promise<boolean> => {
-  const record = await queries.verificationRecords.findActiveVerificationRecordById(id);
-  if (record?.userId !== userId) {
-    return false;
-  }
-
-  const result = verificationRecordDataGuard.safeParse({
-    ...record.data,
-    id: record.id,
-  });
-
-  if (!result.success) {
-    return false;
-  }
-
-  const instance = buildVerificationRecord(libraries, queries, result.data);
-  return instance.isVerified;
-};
 
 /**
  * Auth middleware for OIDC opaque token
@@ -68,23 +29,11 @@ export default function koaOidcAuth<StateT, ContextT extends IRouterParamContext
     assertThat(accountId, new RequestError({ code: 'auth.unauthorized', status: 401 }));
     assertThat(scopes.has('openid'), new RequestError({ code: 'auth.forbidden', status: 403 }));
 
-    const verificationRecordId = request.headers[verificationRecordIdHeader];
-    const identityVerified =
-      typeof verificationRecordId === 'string'
-        ? await getVerificationRecordResultById({
-            id: verificationRecordId,
-            queries: tenant.queries,
-            libraries: tenant.libraries,
-            userId: accountId,
-          })
-        : false;
-
     ctx.auth = {
       type: 'user',
       id: accountId,
       scopes,
       clientId,
-      identityVerified,
     };
 
     return next();

--- a/packages/core/src/middleware/koa-auth/types.ts
+++ b/packages/core/src/middleware/koa-auth/types.ts
@@ -4,8 +4,6 @@ type Auth = {
   type: 'user' | 'app';
   id: string;
   scopes: Set<string>;
-  /** If the request is verified by a verification record, this will be set to `true`. */
-  identityVerified?: boolean;
   /** Client ID of the OIDC access token */
   clientId?: string;
 };

--- a/packages/core/src/routes/account/email-and-phone.ts
+++ b/packages/core/src/routes/account/email-and-phone.ts
@@ -33,11 +33,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
       status: [204, 400, 401, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
-      assertThat(
-        identityVerified,
-        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
-      );
+      const { id: userId, scopes } = ctx.auth;
       const { email, newIdentifierVerificationRecordId } = ctx.guard.body;
       const { fields } = ctx.accountCenter;
       assertThat(
@@ -79,11 +75,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
       status: [204, 400, 401],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
-      assertThat(
-        identityVerified,
-        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
-      );
+      const { id: userId, scopes } = ctx.auth;
       const { fields } = ctx.accountCenter;
       assertThat(
         fields.email === AccountCenterControlValue.Edit,
@@ -122,11 +114,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
       status: [204, 400, 401, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
-      assertThat(
-        identityVerified,
-        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
-      );
+      const { id: userId, scopes } = ctx.auth;
       const { phone, newIdentifierVerificationRecordId } = ctx.guard.body;
       const { fields } = ctx.accountCenter;
       assertThat(
@@ -164,11 +152,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
       status: [204, 400, 401],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
-      assertThat(
-        identityVerified,
-        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
-      );
+      const { id: userId, scopes } = ctx.auth;
       const { fields } = ctx.accountCenter;
       assertThat(
         fields.phone === AccountCenterControlValue.Edit,

--- a/packages/core/src/routes/account/identities.ts
+++ b/packages/core/src/routes/account/identities.ts
@@ -31,11 +31,7 @@ export default function identitiesRoutes<T extends UserRouter>(
       status: [204, 400, 401],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
-      assertThat(
-        identityVerified,
-        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
-      );
+      const { id: userId, scopes } = ctx.auth;
       const { newIdentifierVerificationRecordId } = ctx.guard.body;
       const { fields } = ctx.accountCenter;
       assertThat(
@@ -89,11 +85,7 @@ export default function identitiesRoutes<T extends UserRouter>(
       status: [204, 400, 401, 404],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
-      assertThat(
-        identityVerified,
-        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
-      );
+      const { id: userId, scopes } = ctx.auth;
       const { target } = ctx.guard.params;
       const { fields } = ctx.accountCenter;
       assertThat(

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -149,11 +149,7 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
       status: [204, 400, 401, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, identityVerified } = ctx.auth;
-      assertThat(
-        identityVerified,
-        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
-      );
+      const { id: userId } = ctx.auth;
       const { password } = ctx.guard.body;
       const { fields } = ctx.accountCenter;
       assertThat(

--- a/packages/core/src/routes/account/mfa-verifications.ts
+++ b/packages/core/src/routes/account/mfa-verifications.ts
@@ -71,11 +71,7 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
       status: [204, 400, 401],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
-      assertThat(
-        identityVerified,
-        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
-      );
+      const { id: userId, scopes } = ctx.auth;
       const { newIdentifierVerificationRecordId, name } = ctx.guard.body;
       const { fields } = ctx.accountCenter;
       assertThat(
@@ -134,11 +130,7 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
       status: [200, 400, 401],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
-      assertThat(
-        identityVerified,
-        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
-      );
+      const { id: userId, scopes } = ctx.auth;
       const { name } = ctx.guard.body;
       const { fields } = ctx.accountCenter;
       assertThat(
@@ -182,11 +174,7 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
       status: [204, 400, 401],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
-      assertThat(
-        identityVerified,
-        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
-      );
+      const { id: userId, scopes } = ctx.auth;
       const { fields } = ctx.accountCenter;
       assertThat(
         fields.mfa === AccountCenterControlValue.Edit,

--- a/packages/integration-tests/src/api/my-account.ts
+++ b/packages/integration-tests/src/api/my-account.ts
@@ -1,8 +1,6 @@
 import { type UserProfileResponse } from '@logto/schemas';
 import { type KyInstance } from 'ky';
 
-const verificationRecordIdHeader = 'logto-verification-id';
-
 export const updatePassword = async (
   api: KyInstance,
   verificationRecordId: string,
@@ -10,7 +8,6 @@ export const updatePassword = async (
 ) =>
   api.post('api/my-account/password', {
     json: { password },
-    headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
 export const updatePrimaryEmail = async (
@@ -21,13 +18,10 @@ export const updatePrimaryEmail = async (
 ) =>
   api.post('api/my-account/primary-email', {
     json: { email, newIdentifierVerificationRecordId },
-    headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
 export const deletePrimaryEmail = async (api: KyInstance, verificationRecordId: string) =>
-  api.delete('api/my-account/primary-email', {
-    headers: { [verificationRecordIdHeader]: verificationRecordId },
-  });
+  api.delete('api/my-account/primary-email');
 
 export const updatePrimaryPhone = async (
   api: KyInstance,
@@ -37,13 +31,10 @@ export const updatePrimaryPhone = async (
 ) =>
   api.post('api/my-account/primary-phone', {
     json: { phone, newIdentifierVerificationRecordId },
-    headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
 export const deletePrimaryPhone = async (api: KyInstance, verificationRecordId: string) =>
-  api.delete('api/my-account/primary-phone', {
-    headers: { [verificationRecordIdHeader]: verificationRecordId },
-  });
+  api.delete('api/my-account/primary-phone');
 
 export const updateIdentities = async (
   api: KyInstance,
@@ -52,7 +43,6 @@ export const updateIdentities = async (
 ) =>
   api.post('api/my-account/identities', {
     json: { newIdentifierVerificationRecordId },
-    headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
 export const deleteIdentity = async (
@@ -60,9 +50,7 @@ export const deleteIdentity = async (
   target: string,
   verificationRecordId: string
 ) =>
-  api.delete(`api/my-account/identities/${target}`, {
-    headers: { [verificationRecordIdHeader]: verificationRecordId },
-  });
+  api.delete(`api/my-account/identities/${target}`);
 
 export const updateUser = async (api: KyInstance, body: Record<string, unknown>) =>
   api.patch('api/my-account', { json: body }).json<Partial<UserProfileResponse>>();

--- a/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
@@ -60,17 +60,10 @@ describe('account (email and phone)', () => {
       });
       const newEmail = generateEmail();
 
-      await expectRejects(
-        updatePrimaryEmail(
-          api,
-          newEmail,
-          'invalid-verification-record-id',
-          'new-verification-record-id'
-        ),
-        {
-          code: 'verification_record.permission_denied',
-          status: 401,
-        }
+      await updatePrimaryEmail(
+        api,
+        newEmail,
+        'new-verification-record-id'
       );
 
       await deleteDefaultTenantUser(user.id);
@@ -192,10 +185,7 @@ describe('account (email and phone)', () => {
         scopes: [UserScope.Profile, UserScope.Email],
       });
 
-      await expectRejects(deletePrimaryEmail(api, 'invalid-verification-record-id'), {
-        code: 'verification_record.permission_denied',
-        status: 401,
-      });
+      await deletePrimaryEmail(api, 'invalid-verification-record-id');
 
       await deleteDefaultTenantUser(user.id);
     });
@@ -282,16 +272,13 @@ describe('account (email and phone)', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    it('should fail if verification record is invalid', async () => {
+    it('should ignore invalid verification record', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile, UserScope.Phone],
       });
 
-      await expectRejects(deletePrimaryPhone(api, 'invalid-verification-record-id'), {
-        code: 'verification_record.permission_denied',
-        status: 401,
-      });
+      await deletePrimaryPhone(api, 'invalid-verification-record-id');
 
       await deleteDefaultTenantUser(user.id);
     });
@@ -431,10 +418,7 @@ describe('account (email and phone)', () => {
         scopes: [UserScope.Profile, UserScope.Phone],
       });
 
-      await expectRejects(deletePrimaryPhone(api, 'invalid-verification-record-id'), {
-        code: 'verification_record.permission_denied',
-        status: 401,
-      });
+      await deletePrimaryPhone(api, 'invalid-verification-record-id');
 
       await deleteDefaultTenantUser(user.id);
     });

--- a/packages/integration-tests/src/tests/api/account/index.test.ts
+++ b/packages/integration-tests/src/tests/api/account/index.test.ts
@@ -262,15 +262,12 @@ describe('account', () => {
   });
 
   describe('POST /my-account/password', () => {
-    it('should fail if verification record is invalid', async () => {
+    it('should ignore invalid verification record', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password);
       const newPassword = generatePassword();
 
-      await expectRejects(updatePassword(api, 'invalid-varification-record-id', newPassword), {
-        code: 'verification_record.permission_denied',
-        status: 401,
-      });
+      await updatePassword(api, 'invalid-varification-record-id', newPassword);
 
       await deleteDefaultTenantUser(user.id);
     });

--- a/packages/integration-tests/src/tests/api/account/social.test.ts
+++ b/packages/integration-tests/src/tests/api/account/social.test.ts
@@ -70,13 +70,7 @@ describe('my-account (social)', () => {
         scopes: [UserScope.Profile, UserScope.Identities],
       });
 
-      await expectRejects(
-        updateIdentities(api, 'invalid-verification-record-id', 'new-verification-record-id'),
-        {
-          code: 'verification_record.permission_denied',
-          status: 401,
-        }
-      );
+      await updateIdentities(api, 'new-verification-record-id');
 
       await deleteDefaultTenantUser(user.id);
     });
@@ -186,13 +180,7 @@ describe('my-account (social)', () => {
         scopes: [UserScope.Profile, UserScope.Identities],
       });
 
-      await expectRejects(
-        deleteIdentity(api, mockSocialConnectorTarget, 'invalid-verification-record-id'),
-        {
-          code: 'verification_record.permission_denied',
-          status: 401,
-        }
-      );
+      await deleteIdentity(api, mockSocialConnectorTarget, 'invalid-verification-record-id');
 
       await deleteDefaultTenantUser(user.id);
     });


### PR DESCRIPTION
## Summary
- remove verificationRecordId header logic
- drop identityVerified property from WithAuthContext
- rely on Account Center settings in account routes
- update integration test helpers and cases
- document cleanup

## Testing
- `pnpm ci:lint` *(fails: eslint errors in other packages)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_684eb4202e4c832fa4ef9b1a91c1e695