### PR TITLE
Refactor hook utils

### DIFF
--- a/docs-ref/hook-utils-refactor.md
+++ b/docs-ref/hook-utils-refactor.md
@@ -1,0 +1,14 @@
+# Hook Utils Refactor
+
+**File paths**
+- `packages/core/src/libraries/hook/utils.ts`
+- `packages/core/src/libraries/hook/context-manager.ts`
+- `packages/core/src/libraries/hook/utils.test.ts`
+
+**Key changes**
+- Replaced separate key builder and event check utilities with `resolveManagementApiDataHookEvent`.
+- Updated `DataHookContextManager` to use the new helper when determining registered events.
+- Added unit tests covering the helper for registered and unregistered routes.
+
+**New dependencies / environment variables**
+- None.

--- a/packages/core/src/libraries/hook/context-manager.ts
+++ b/packages/core/src/libraries/hook/context-manager.ts
@@ -14,8 +14,7 @@ import { type IRouterParamContext } from 'koa-router';
 
 import {
   buildManagementApiContext,
-  buildManagementApiDataHookRegistrationKey,
-  hasRegisteredDataHookEvent,
+  resolveManagementApiDataHookEvent,
 } from './utils.js';
 
 type DataHookMetadata = {
@@ -63,14 +62,14 @@ export class DataHookContextManager {
   ): Readonly<[DataHookEvent, DataHookContext]> | undefined {
     const { method, _matchedRoute: matchedRoute } = ctx;
 
-    const key = buildManagementApiDataHookRegistrationKey(method, matchedRoute);
+    const event = resolveManagementApiDataHookEvent(method, matchedRoute);
 
-    if (!hasRegisteredDataHookEvent(key)) {
+    if (!event) {
       return;
     }
 
     return Object.freeze([
-      managementApiHooksRegistration[key],
+      event,
       {
         ...buildManagementApiContext(ctx),
         data: ctx.response.body,

--- a/packages/core/src/libraries/hook/utils.test.ts
+++ b/packages/core/src/libraries/hook/utils.test.ts
@@ -1,4 +1,8 @@
-import { type HookEvent, InteractionHookEvent } from '@logto/schemas';
+import {
+  type HookEvent,
+  InteractionHookEvent,
+  managementApiHooksRegistration,
+} from '@logto/schemas';
 import { createMockUtils } from '@logto/shared/esm';
 import ky from 'ky';
 
@@ -16,7 +20,11 @@ mockEsm('#src/utils/sign.js', () => ({
   sign: () => mockSignature,
 }));
 
-const { generateHookTestPayload, sendWebhookRequest } = await import('./utils.js');
+const {
+  generateHookTestPayload,
+  sendWebhookRequest,
+  resolveManagementApiDataHookEvent,
+} = await import('./utils.js');
 
 describe('sendWebhookRequest', () => {
   it('should call got.post with correct values', async () => {
@@ -46,5 +54,20 @@ describe('sendWebhookRequest', () => {
       retry: { limit: 3 },
       timeout: 10_000,
     });
+  });
+});
+
+describe('resolveManagementApiDataHookEvent', () => {
+  it('should return event for registered route', () => {
+    const [key, event] = Object.entries(managementApiHooksRegistration)[0];
+    const [method, route] = key.split(' ') as [string, string];
+
+    expect(resolveManagementApiDataHookEvent(method, route)).toBe(event);
+  });
+
+  it('should return undefined for unregistered route', () => {
+    expect(
+      resolveManagementApiDataHookEvent('GET', '/unregistered')
+    ).toBeUndefined();
   });
 });

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -2,6 +2,7 @@ import {
   ApplicationType,
   InteractionHookEvent,
   managementApiHooksRegistration,
+  type DataHookEvent,
   type HookConfig,
   type HookEvent,
   type HookEventPayload,
@@ -105,14 +106,11 @@ export const generateHookTestPayload = (hookId: string, event: HookEvent): HookE
   };
 };
 
-export const buildManagementApiDataHookRegistrationKey = (
+export const resolveManagementApiDataHookEvent = (
   method: string,
   route: IRouterParamContext['_matchedRoute']
-) => `${method} ${route}`;
-
-export const hasRegisteredDataHookEvent = (
-  key: string
-): key is keyof typeof managementApiHooksRegistration => key in managementApiHooksRegistration;
+): DataHookEvent | undefined =>
+  managementApiHooksRegistration[`${method} ${route}`];
 
 export const buildManagementApiContext = (
   ctx: IRouterParamContext & Context


### PR DESCRIPTION
## Summary
- merge hook registration utilities into new `resolveManagementApiDataHookEvent`
- update `DataHookContextManager` to use the helper
- add unit tests for the new helper
- document the refactor

## Testing
- `pnpm ci:lint` *(fails: eslint errors in connectors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: test failures in other packages)*

------
https://chatgpt.com/codex/tasks/task_e_684eb4163548832fb2dbffeec627b6c9