### PR TITLE
Add localized organization invitation errors

### DIFF
--- a/docs-ref/organization-invitation-error-messages.md
+++ b/docs-ref/organization-invitation-error-messages.md
@@ -1,0 +1,15 @@
+# Organization Invitation Error Messages
+
+**File paths**
+- `packages/phrases/src/locales/*/errors/organization-invitation.ts`
+- `packages/core/src/routes/organization-invitation/index.ts`
+- `packages/core/src/libraries/organization-invitation.ts`
+- `packages/integration-tests/src/tests/api/organization/organization-invitation.*.test.ts`
+
+**Key changes**
+- Added `accepted_user_id_required` and `expires_at_future_required` error codes.
+- Routes and library now throw localized `RequestError`s using these codes.
+- Updated integration tests to expect the new localized codes.
+
+**New dependencies / environment variables**
+- None.

--- a/packages/core/src/libraries/organization-invitation.ts
+++ b/packages/core/src/libraries/organization-invitation.ts
@@ -144,7 +144,6 @@ export class OrganizationInvitationLibrary {
     status: OrganizationInvitationStatus.Accepted,
     acceptedUserId: string
   ): Promise<OrganizationInvitationEntity>;
-  // TODO: Error i18n
   async updateStatus(
     id: string,
     status: OrganizationInvitationStatus,
@@ -165,9 +164,11 @@ export class OrganizationInvitationLibrary {
 
       switch (status) {
         case OrganizationInvitationStatus.Accepted: {
-          // Normally this shouldn't happen, so we use `TypeError` instead of `RequestError`.
           if (!acceptedUserId) {
-            throw new TypeError('The `acceptedUserId` is required when accepting an invitation.');
+            throw new RequestError({
+              status: 422,
+              code: 'organization_invitation.accepted_user_id_required',
+            });
           }
 
           const user = await userQueries.findUserById(acceptedUserId);

--- a/packages/core/src/routes/organization-invitation/index.ts
+++ b/packages/core/src/routes/organization-invitation/index.ts
@@ -76,8 +76,8 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
       assertThat(
         body.expiresAt > Date.now(),
         new RequestError({
-          code: 'request.invalid_input',
-          details: 'The value of `expiresAt` must be in the future.',
+          code: 'organization_invitation.expires_at_future_required',
+          status: 400,
         })
       );
 
@@ -144,13 +144,11 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
         return next();
       }
 
-      // TODO: Error i18n
       assertThat(
         acceptedUserId,
         new RequestError({
           status: 422,
-          code: 'request.invalid_input',
-          details: 'The `acceptedUserId` is required when accepting an invitation.',
+          code: 'organization_invitation.accepted_user_id_required',
         })
       );
 

--- a/packages/integration-tests/src/tests/api/organization/organization-invitation.creation.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-invitation.creation.test.ts
@@ -155,7 +155,7 @@ describe('organization invitation creation', () => {
       })
       .catch((error: unknown) => error);
 
-    await expectErrorResponse(error, 400, 'request.invalid_input');
+    await expectErrorResponse(error, 400, 'organization_invitation.expires_at_future_required');
   });
 
   it('should not be able to create invitations if the invitee is already a member of the organization', async () => {
@@ -172,7 +172,7 @@ describe('organization invitation creation', () => {
       })
       .catch((error: unknown) => error);
 
-    await expectErrorResponse(error, 422, 'request.invalid_input');
+    await expectErrorResponse(error, 422, 'organization_invitation.invitee_already_member');
   });
 
   it('should not be able to create invitations with an invalid email', async () => {

--- a/packages/integration-tests/src/tests/api/organization/organization-invitation.status.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-invitation.status.test.ts
@@ -48,7 +48,7 @@ describe('organization invitation status update', () => {
     const error = await invitationApi
       .updateStatus(invitation.id, OrganizationInvitationStatus.Accepted)
       .catch((error: unknown) => error);
-    await expectErrorResponse(error, 422, 'request.invalid_input');
+    await expectErrorResponse(error, 422, 'organization_invitation.status_unchangeable');
   });
 
   it('should be able to accept an invitation', async () => {
@@ -128,7 +128,7 @@ describe('organization invitation status update', () => {
       .updateStatus(invitation.id, OrganizationInvitationStatus.Accepted, user.id)
       .catch((error: unknown) => error);
 
-    await expectErrorResponse(error, 422, 'request.invalid_input');
+    await expectErrorResponse(error, 422, 'organization_invitation.accepted_user_email_mismatch');
   });
 
   it('should not be able to accept an invitation with an invalid user id', async () => {
@@ -162,6 +162,6 @@ describe('organization invitation status update', () => {
       .updateStatus(invitation.id, OrganizationInvitationStatus.Accepted)
       .catch((error: unknown) => error);
 
-    await expectErrorResponse(error, 422, 'request.invalid_input');
+    await expectErrorResponse(error, 422, 'organization_invitation.status_unchangeable');
   });
 });

--- a/packages/phrases/src/locales/ar/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/ar/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/de/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/de/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/en/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/en/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/es/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/es/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'El invitado ya es miembro de la organización.',
   status_unchangeable: 'El estado de la invitación ya no puede cambiarse.',
   accepted_user_email_mismatch: 'El usuario que acepta debe tener el mismo correo electrónico que el invitado.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/fr/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/fr/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/it/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/it/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/ja/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/ja/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/ko/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/ko/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/pl-pl/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/pt-br/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/pt-br/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/pt-pt/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/ru/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/ru/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/tr-tr/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/zh-cn/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/zh-hk/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/zh-tw/errors/index.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/index.ts
@@ -61,10 +61,7 @@ const errors = {
   one_time_token,
   captcha_provider,
   custom_profile_fields,
- <<<<<<< codex/reemplazar-mensajes-de-error-por-claves-de-traducción
   organization_invitation,
-=======
- >>>>>>> master
 };
 
 export default Object.freeze(errors);

--- a/packages/phrases/src/locales/zh-tw/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/organization-invitation.ts
@@ -2,6 +2,8 @@ const organization_invitation = {
   invitee_already_member: 'The invitee is already a member of the organization.',
   status_unchangeable: 'The status of the invitation cannot be changed anymore.',
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
+  accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
+  expires_at_future_required: 'The value of `expiresAt` must be in the future.',
 };
 
 export default Object.freeze(organization_invitation);


### PR DESCRIPTION
## Summary
- add validation error messages for organization invitation routes
- throw localized errors in the invitation route and library
- update tests to check for new error codes
- document organization invitation validation errors

## Testing
- `pnpm ci:lint` *(fails: @logto/connector-alipay-native lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: @logto/cloud-models test:ci)*

------
https://chatgpt.com/codex/tasks/task_e_684eb40ce250832f96ed2b9918c54154