### PR TITLE
Replace tenant type with cloud model

### DIFF
--- a/packages/integration-tests/src/api/tenant.ts
+++ b/packages/integration-tests/src/api/tenant.ts
@@ -1,10 +1,11 @@
 import { type TenantTag } from '@logto/schemas';
-import type { TenantModel } from '@logto/schemas/models';
+import type router from '@logto/cloud/routes';
+import { type GuardedResponse, type RouterRoutes } from '@withtyped/client';
 
 import { cloudApi } from './api.js';
 
-// TODO: Import from cloud package after it's created
-type TenantInfo = Pick<TenantModel, 'id' | 'name' | 'tag' | 'isSuspended' | 'createdAt'>;
+type GetRoutes = RouterRoutes<typeof router>['get'];
+type TenantInfo = GuardedResponse<GetRoutes['/api/tenants']>[number];
 
 export const createTenant = async (
   accessToken: string,


### PR DESCRIPTION
## Summary
- use TenantInfo from the cloud routes package in integration tests

## Testing
- `pnpm ci:lint` *(fails: @logto/connector-alipay-web lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models test suite reports no tests)*

------
https://chatgpt.com/codex/tasks/task_e_684eb408e3b4832fb9fea35c886b9f53