### PR TITLE
fix(console): handle CodeEditor required errors

### DIFF
--- a/docs-ref/code-editor-error-handling.md
+++ b/docs-ref/code-editor-error-handling.md
@@ -1,0 +1,13 @@
+# CodeEditor Required Error Handling
+
+**File paths**
+- `packages/console/src/ds-components/CodeEditor/index.tsx`
+- `packages/console/src/ds-components/__tests__/CodeEditor.test.tsx`
+
+**Key changes**
+- Refactored the component to treat empty error strings as errors.
+- Added a `hasError` flag so boolean or empty-string errors render the default required message.
+- Provided tests covering custom messages and fallback behaviour.
+
+**New dependencies / environment variables**
+- None.

--- a/packages/console/src/ds-components/CodeEditor/index.tsx
+++ b/packages/console/src/ds-components/CodeEditor/index.tsx
@@ -81,8 +81,10 @@ function CodeEditor({
     }
   };
 
-  // TODO @sijie temp solution for required error (the errorMessage is an empty string)
-  const finalErrorMessage = typeof error === 'string' ? error : t('general.required');
+  const hasError = error === '' || Boolean(error);
+
+  const finalErrorMessage =
+    typeof error === 'string' && error.length > 0 ? error : t('general.required');
 
   const maxLineNumberDigits = (value ?? '').split('\n').length.toString().length;
   const isShowingPlaceholder = !value;
@@ -139,7 +141,7 @@ function CodeEditor({
           </SyntaxHighlighter>
         </div>
       </div>
-      {error && <div className={styles.errorMessage}>{finalErrorMessage}</div>}
+      {hasError && <div className={styles.errorMessage}>{finalErrorMessage}</div>}
     </>
   );
 }

--- a/packages/console/src/ds-components/__tests__/CodeEditor.test.tsx
+++ b/packages/console/src/ds-components/__tests__/CodeEditor.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+
+
+import CodeEditor from '../CodeEditor';
+
+describe('<CodeEditor /> error handling', () => {
+  it('shows custom error message', () => {
+    const { getByText } = render(
+      <CodeEditor value="" onChange={() => {}} error="custom" />
+    );
+    expect(getByText('custom')).toBeInTheDocument();
+  });
+
+  it('shows default required message when error is boolean', () => {
+    const { getByText } = render(
+      <CodeEditor value="" onChange={() => {}} error={true} />
+    );
+    expect(getByText('general.required')).toBeInTheDocument();
+  });
+
+  it('shows default required message when error is empty string', () => {
+    const { getByText } = render(
+      <CodeEditor value="" onChange={() => {}} error="" />
+    );
+    expect(getByText('general.required')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- handle empty messages in CodeEditor
- test CodeEditor required error behaviors
- document CodeEditor required message behavior

## Testing
- `pnpm ci:lint` *(fails: connector lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: packages/cloud-models and others)*

------
https://chatgpt.com/codex/tasks/task_e_684eb406df08832fbfa2c35172f3b9c4