### PR TITLE
Clean branding fields on SSO updates

### DIFF
--- a/docs-ref/console-branding-cleanup.md
+++ b/docs-ref/console-branding-cleanup.md
@@ -1,0 +1,12 @@
+# Console SSO Branding Cleanup
+
+**File paths**
+- `packages/console/src/pages/EnterpriseSsoDetails/Experience/index.tsx`
+- `packages/integration-tests/src/tests/console/sso-branding-cleanup.test.ts`
+
+**Key changes**
+- Remove empty branding values before submitting SSO connector updates.
+- Added integration test ensuring PATCH requests omit empty branding fields.
+
+**New dependencies / environment variables**
+- None.

--- a/packages/console/src/pages/EnterpriseSsoDetails/Experience/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Experience/index.tsx
@@ -111,14 +111,23 @@ function Experience({ data, isDeleted, onUpdated, isDarkModeEnabled }: Props) {
       }
 
       try {
+        let parsedFormData = cleanDeep(formDataToSsoConnectorParser(formData), {
+          // To overwrite the `branding` field, which is a JSONB typed column in DB.
+          emptyObjects: false,
+        });
+
+        if (
+          'branding' in parsedFormData &&
+          parsedFormData.branding &&
+          Object.keys(parsedFormData.branding).length === 0
+        ) {
+          const { branding: _branding, ...rest } = parsedFormData;
+          parsedFormData = rest;
+        }
+
         const updatedSsoConnector = await api
-          // TODO: @darcyYe add console test case of clean up `branding` config.
-          // Only keep non-empty values since PATCH operation performs a merge scheme.
           .patch(`api/sso-connectors/${data.id}`, {
-            json: cleanDeep(formDataToSsoConnectorParser(formData), {
-              // To overwrite the `branding` field, which is a JSONB typed column in DB.
-              emptyObjects: false,
-            }),
+            json: parsedFormData,
           })
           .json<SsoConnectorWithProviderConfig>();
 

--- a/packages/integration-tests/src/tests/console/sso-branding-cleanup.test.ts
+++ b/packages/integration-tests/src/tests/console/sso-branding-cleanup.test.ts
@@ -1,0 +1,55 @@
+import { logtoConsoleUrl as logtoConsoleUrlString, newOidcSsoConnectorPayload } from '#src/constants.js';
+import { SsoConnectorApi } from '#src/api/sso-connector.js';
+import { goToConsole, expectToSaveChanges, waitForToast } from '#src/ui-helpers/index.js';
+import { appendPathname, expectNavigation } from '#src/utils.js';
+
+await page.setViewport({ width: 1920, height: 1080 });
+
+describe('enterprise sso branding cleanup', () => {
+  const api = new SsoConnectorApi();
+  const logtoConsoleUrl = new URL(logtoConsoleUrlString);
+  let connectorId: string;
+
+  beforeAll(async () => {
+    const connector = await api.create({
+      ...newOidcSsoConnectorPayload,
+      branding: {
+        displayName: 'Cleanup',
+        logo: 'https://logto.io/logo.png',
+        darkLogo: 'https://logto.io/logo-dark.png',
+      },
+    });
+    connectorId = connector.id;
+    await goToConsole();
+    await expectNavigation(
+      page.goto(
+        appendPathname(`/console/enterprise-sso/${connectorId}/experience`, logtoConsoleUrl).href
+      )
+    );
+  });
+
+  afterAll(async () => {
+    await api.cleanUp();
+  });
+
+  it('should omit empty branding fields in patch request', async () => {
+    const patchRequestPromise = page.waitForRequest(
+      (request) =>
+        request.method() === 'PATCH' &&
+        request.url().includes(`/api/sso-connectors/${connectorId}`)
+    );
+
+    await expect(page).toFillForm('form', {
+      'branding.displayName': '',
+      'branding.logo': '',
+      'branding.darkLogo': '',
+    });
+
+    await expectToSaveChanges(page);
+    await waitForToast(page, { text: 'Saved' });
+
+    const patchRequest = await patchRequestPromise;
+    const body = JSON.parse(patchRequest.postData() ?? '{}');
+    expect(body).not.toHaveProperty('branding');
+  });
+});


### PR DESCRIPTION
## Summary
- strip empty branding on Enterprise SSO edit
- test PATCH request omits empty branding fields
- document branding cleanup behavior

## Testing
- `pnpm ci:lint` *(fails: connector packages lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models test failure)*

------
https://chatgpt.com/codex/tasks/task_e_684eb4019b18832f9baed912270b9cab