### PR TITLE
Refactor skip-mfa hook

### DIFF
--- a/docs-ref/skip-mfa-error-refactor.md
+++ b/docs-ref/skip-mfa-error-refactor.md
@@ -1,0 +1,14 @@
+# Skip MFA Hook Refactor
+
+**File paths**
+- `packages/experience/src/hooks/use-skip-mfa.ts`
+- `packages/experience/src/hooks/use-skip-mfa-error-handler.ts`
+- `packages/experience/src/hooks/__tests__/use-skip-mfa.test.ts`
+
+**Key changes**
+- Introduced `useSkipMfaErrorHandler` to resolve the interaction event from the current location and supply the correct error handlers.
+- Updated `useSkipMfa` to leverage the new helper for clearer error processing.
+- Added unit tests covering sign-in and registration flows.
+
+**New dependencies / environment variables**
+- None.

--- a/packages/experience/src/hooks/__tests__/use-skip-mfa.test.ts
+++ b/packages/experience/src/hooks/__tests__/use-skip-mfa.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
+import { InteractionEvent } from '@logto/schemas';
+import { renderHook } from '@testing-library/react-hooks';
+import * as reactRouterDom from 'react-router-dom';
+
+import useSkipMfa from '../use-skip-mfa';
+
+const mockAsyncSkipMfa = jest.fn();
+const mockRedirectTo = jest.fn();
+const mockHandleError = jest.fn();
+const mockErrorHandlers = {};
+
+jest.mock('../use-api', () => ({
+  __esModule: true,
+  default: () => mockAsyncSkipMfa,
+}));
+
+jest.mock('../use-global-redirect-to', () => ({
+  __esModule: true,
+  default: () => mockRedirectTo,
+}));
+
+jest.mock('../use-error-handler', () => ({
+  __esModule: true,
+  default: () => mockHandleError,
+}));
+
+jest.mock('../use-submit-interaction-error-handler', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockErrorHandlers),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+}));
+const useLocationMock = reactRouterDom.useLocation as jest.Mock;
+const useSubmitInteractionErrorHandler = jest.requireMock('../use-submit-interaction-error-handler') as jest.Mock;
+
+describe('useSkipMfa', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects when skipping mfa succeeds', async () => {
+    useLocationMock.mockReturnValue({});
+    mockAsyncSkipMfa.mockResolvedValue([null, { redirectTo: '/home' }]);
+    const { result } = renderHook(() => useSkipMfa());
+
+    await result.current();
+
+    expect(mockRedirectTo).toBeCalledWith('/home');
+    expect(mockHandleError).not.toBeCalled();
+  });
+
+  it('handles error with sign-in flow', async () => {
+    useLocationMock.mockReturnValue({});
+    mockAsyncSkipMfa.mockResolvedValue([new Error('fail')]);
+    const { result } = renderHook(() => useSkipMfa());
+
+    await result.current();
+
+    expect(useSubmitInteractionErrorHandler).toBeCalledWith(InteractionEvent.SignIn, { replace: true });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- testing error handling
+    expect(mockHandleError).toBeCalledWith(expect.any(Error), mockErrorHandlers);
+  });
+
+  it('handles error with registration flow', async () => {
+    useLocationMock.mockReturnValue({ state: { interactionEvent: InteractionEvent.Register } });
+    mockAsyncSkipMfa.mockResolvedValue([new Error('fail')]);
+    const { result } = renderHook(() => useSkipMfa());
+
+    await result.current();
+
+    expect(useSubmitInteractionErrorHandler).toBeCalledWith(InteractionEvent.Register, { replace: true });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- testing error handling
+    expect(mockHandleError).toBeCalledWith(expect.any(Error), mockErrorHandlers);
+  });
+});
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */

--- a/packages/experience/src/hooks/use-skip-mfa-error-handler.ts
+++ b/packages/experience/src/hooks/use-skip-mfa-error-handler.ts
@@ -1,0 +1,30 @@
+import { InteractionEvent } from '@logto/schemas';
+import { useCallback, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { getInteractionEventFromState } from '@/apis/utils';
+
+import useErrorHandler from './use-error-handler';
+import useSubmitInteractionErrorHandler from './use-submit-interaction-error-handler';
+
+const useSkipMfaErrorHandler = () => {
+  const { state } = useLocation();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- location state is unknown
+  const interactionEvent = useMemo(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- state type is unknown
+    () => getInteractionEventFromState(state) ?? InteractionEvent.SignIn,
+    [state]
+  );
+
+  const submitErrorHandler = useSubmitInteractionErrorHandler(interactionEvent, {
+    replace: true,
+  });
+  const handleError = useErrorHandler();
+
+  return useCallback(
+    (error: unknown) => handleError(error, submitErrorHandler),
+    [handleError, submitErrorHandler]
+  );
+};
+
+export default useSkipMfaErrorHandler;

--- a/packages/experience/src/hooks/use-skip-mfa.ts
+++ b/packages/experience/src/hooks/use-skip-mfa.ts
@@ -1,25 +1,16 @@
-import { InteractionEvent } from '@logto/schemas';
 import { useCallback } from 'react';
 
 import { skipMfa } from '@/apis/experience';
 
 import useApi from './use-api';
-import useErrorHandler from './use-error-handler';
 import useGlobalRedirectTo from './use-global-redirect-to';
-import useSubmitInteractionErrorHandler from './use-submit-interaction-error-handler';
+import useSkipMfaErrorHandler from './use-skip-mfa-error-handler';
 
 const useSkipMfa = () => {
   const asyncSkipMfa = useApi(skipMfa);
   const redirectTo = useGlobalRedirectTo();
 
-  const handleError = useErrorHandler();
-  const signInErrorHandler = useSubmitInteractionErrorHandler(InteractionEvent.SignIn, {
-    replace: true,
-  });
-  const handleSkipMfaError = useCallback(
-    (error: unknown) => handleError(error, signInErrorHandler),
-    [handleError, signInErrorHandler]
-  );
+  const handleSkipMfaError = useSkipMfaErrorHandler();
 
   return useCallback(async () => {
     const [error, result] = await asyncSkipMfa();


### PR DESCRIPTION
## Summary
- clarify skip MFA error handling flow
- add tests for skip MFA hook
- document skip MFA hook refactor

## Testing
- `pnpm ci:lint` *(fails: connector packages lint issues)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684eb3ff9654832f871cda580c6db08d