### PR TITLE
Add setup script for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ ADMIN_ENDPOINT=http://localhost:3002
 # OpenSearch powers the search index
 ```
 
+A helper script is available to install dependencies and launch the development
+server. It will download Node.js `22.14.0` locally if needed and prepare pnpm.
+
+```bash
+./run/setup.sh
+```
+
 ### Migrate from PostgreSQL
 
 If you are upgrading from an older release using PostgreSQL, run:
@@ -102,7 +109,7 @@ Seed initial data and start the development server:
 
 ```bash
 pnpm cli db seed
-pnpm dev
+./run/setup.sh
 ```
 
 Run the test suite with:

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REQUIRED_NODE_VERSION="22.14.0"
+NODE_DIR="$(dirname "$0")/node"
+
+version_ge() {
+  [ "$(printf '%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]
+}
+
+needs_node() {
+  if command -v node >/dev/null 2>&1; then
+    local current
+    current="$(node -v | sed 's/^v//')"
+    if version_ge "$current" "$REQUIRED_NODE_VERSION"; then
+      return 1
+    fi
+  fi
+  return 0
+}
+
+if needs_node; then
+  echo "Installing Node.js $REQUIRED_NODE_VERSION locally..."
+  mkdir -p "$NODE_DIR"
+  curl -Ls "https://nodejs.org/dist/v$REQUIRED_NODE_VERSION/node-v$REQUIRED_NODE_VERSION-linux-x64.tar.xz" |
+    tar -xJ --strip-components=1 -C "$NODE_DIR"
+  export PATH="$NODE_DIR/bin:$PATH"
+else
+  echo "Using system Node $(node -v)"
+fi
+
+corepack enable
+corepack prepare pnpm@9 --activate
+
+pnpm install
+pnpm prepack
+
+pnpm dev


### PR DESCRIPTION
## Summary
- add `run/setup.sh` for automatic Node install and dev startup
- document new script in README

## Testing
- `pnpm i`
- `pnpm ci:lint` *(fails: unsafe calls in alipay-native)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: Test failed in cloud-models)*

------
https://chatgpt.com/codex/tasks/task_e_684f5cf09bbc832fbae969ea66513c88