### PR TITLE
Centralize WebAuthn option helpers

### DIFF
--- a/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
@@ -21,7 +21,7 @@ import {
 import {
   generateWebAuthnAuthenticationOptions,
   generateWebAuthnRegistrationOptions,
-} from '#src/utils/webauthn-shared.js';
+} from '#src/routes/interaction/utils/webauthn.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -96,16 +96,9 @@ export class WebAuthnVerification implements MfaVerificationRecord<VerificationT
    * This method is used to generate the WebAuthn registration options for the user.
    * The WebAuthn registration options is used to register a new WebAuthn credential for the user.
    *
- <<<<<<< codex/crear-módulo-compartido-webauthn
-   * Refers to the {@link generateWebAuthnRegistrationOptions} function in the
-   * `utils/webauthn-shared.ts` file. Keep it as the single source of truth for
-   * generating the WebAuthn registration options.
- =======
-   * Refers to the {@link generateWebAuthnRegistrationOptions} function in
-   * `interaction/utils/webauthn-options.ts` file.
-   * Keep it as the single source of truth for generating the WebAuthn registration options.
-   * TODO: Consider relocating the function under a shared folder
- >>>>>>> master
+* Refers to the {@link generateWebAuthnRegistrationOptions} function in
+* `interaction/utils/webauthn.ts` file. Keep it as the single source of truth
+* for generating the WebAuthn registration options.
    */
   async generateWebAuthnRegistrationOptions(rpId: string): Promise<WebAuthnRegistrationOptions> {
     const user = await this.findUser();
@@ -171,16 +164,9 @@ export class WebAuthnVerification implements MfaVerificationRecord<VerificationT
    * This method is used to generate the WebAuthn authentication options for the user.
    * The WebAuthn authentication options is used to authenticate the user using existing WebAuthn credentials.
    *
- <<<<<<< codex/crear-módulo-compartido-webauthn
-   * Refers to the {@link generateWebAuthnAuthenticationOptions} function in the
-   * `utils/webauthn-shared.ts` file. Keep it as the single source of truth for
-   * generating the WebAuthn authentication options.
- =======
    * Refers to the {@link generateWebAuthnAuthenticationOptions} function in
-   * `interaction/utils/webauthn-options.ts` file.
-   * Keep it as the single source of truth for generating the WebAuthn authentication options.
-   * TODO: Consider relocating the function under a shared folder
- >>>>>>> master
+   * `interaction/utils/webauthn.ts` file. Keep it as the single source of truth
+   * for generating the WebAuthn authentication options.
    *
    * @throws {RequestError} with status 400, if no WebAuthn credentials are found for the user.
    */

--- a/packages/core/src/routes/interaction/additional.test.ts
+++ b/packages/core/src/routes/interaction/additional.test.ts
@@ -56,7 +56,7 @@ const { sendVerificationCodeToIdentifier } = await mockEsmWithActual(
 );
 
 const { generateWebAuthnRegistrationOptions, generateWebAuthnAuthenticationOptions } =
-  await mockEsmWithActual('#src/utils/webauthn-shared.js', () => ({
+  await mockEsmWithActual('./utils/webauthn.js', () => ({
     generateWebAuthnRegistrationOptions: jest
       .fn()
       .mockResolvedValue(mockWebAuthnRegistrationOptions),

--- a/packages/core/src/routes/interaction/additional.ts
+++ b/packages/core/src/routes/interaction/additional.ts
@@ -41,7 +41,7 @@ import { sendVerificationCodeToIdentifier } from './utils/verification-code-vali
 import {
   generateWebAuthnAuthenticationOptions,
   generateWebAuthnRegistrationOptions,
-} from '#src/utils/webauthn-shared.js';
+} from './utils/webauthn.js';
 import { verifyIdentifier } from './verifications/index.js';
 import verifyProfile from './verifications/profile-verification.js';
 

--- a/packages/core/src/routes/interaction/utils/webauthn.test.ts
+++ b/packages/core/src/routes/interaction/utils/webauthn.test.ts
@@ -32,17 +32,12 @@ const {
     .mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 1 } }),
 }));
 
-const { generateWebAuthnRegistrationOptions, generateWebAuthnAuthenticationOptions } =
- <<<<<<< codex/crear-módulo-compartido-webauthn
-  await import('../../../utils/webauthn-shared.js');
-const { verifyWebAuthnRegistration, verifyWebAuthnAuthentication } = await import('./webauthn.js');
- =======
-  await import('./webauthn-options.js');
 const {
+  generateWebAuthnRegistrationOptions,
+  generateWebAuthnAuthenticationOptions,
   verifyWebAuthnRegistration,
   verifyWebAuthnAuthentication,
-} = await import('../experience/utils/verification/webauthn.js');
- >>>>>>> master
+} = await import('./webauthn.js');
 
 const rpId = 'logto.io';
 const origin = 'https://logto.io';

--- a/packages/core/src/routes/interaction/utils/webauthn.ts
+++ b/packages/core/src/routes/interaction/utils/webauthn.ts
@@ -1,0 +1,9 @@
+export {
+  verifyWebAuthnRegistration,
+  verifyWebAuthnAuthentication,
+} from '../experience/utils/verification/webauthn.js';
+
+export {
+  generateWebAuthnRegistrationOptions,
+  generateWebAuthnAuthenticationOptions,
+} from '#src/utils/webauthn-shared.js';

--- a/packages/core/src/routes/interaction/verifications/mfa-payload-verification.test.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-payload-verification.test.ts
@@ -36,7 +36,7 @@ const { validateTotpToken } = mockEsm('../utils/totp-validation.js', () => ({
 }));
 
 const { verifyWebAuthnAuthentication, verifyWebAuthnRegistration } = mockEsm(
-  '../../experience/utils/verification/webauthn.js',
+  '../utils/webauthn.js',
   () => ({
     verifyWebAuthnAuthentication: jest.fn(),
     verifyWebAuthnRegistration: jest.fn().mockResolvedValue({

--- a/packages/core/src/routes/interaction/verifications/mfa-payload-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-payload-verification.ts
@@ -30,7 +30,7 @@ import { validateTotpToken } from '../utils/totp-validation.js';
 import {
   verifyWebAuthnAuthentication,
   verifyWebAuthnRegistration,
-} from '../../experience/utils/verification/webauthn.js';
+} from '../utils/webauthn.js';
 
 const verifyBindTotp = async (
   interactionStorage: AnonymousInteractionResult,


### PR DESCRIPTION
## Summary
- create `interaction/utils/webauthn.ts` to re-export shared helpers
- update additional route to use the new util
- refactor WebAuthn verification class to import from interaction util
- fix related tests and imports

## Testing
- `pnpm ci:lint` *(fails: eslint errors in unrelated packages)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: test failures in unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_684f46e118ac832fbcddac0b9b7aa437