### PR TITLE
Fix pending organization invitation test

### DIFF
--- a/packages/integration-tests/src/tests/api/organization/organization-invitation.status.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-invitation.status.test.ts
@@ -112,6 +112,21 @@ describe('organization invitation status update', () => {
     );
   });
 
+  it('should require acceptedUserId when accepting an invitation', async () => {
+    const organization = await organizationApi.create({ name: 'test' });
+    const invitation = await invitationApi.create({
+      organizationId: organization.id,
+      invitee: `${randomId()}@example.com`,
+      expiresAt: Date.now() + 1_000_000,
+    });
+
+    const error = await invitationApi
+      .updateStatus(invitation.id, OrganizationInvitationStatus.Accepted)
+      .catch((error: unknown) => error);
+
+    await expectErrorResponse(error, 422, 'organization_invitation.accepted_user_id_required');
+  });
+
   it('should not be able to accept an invitation with a different email', async () => {
     const organization = await organizationApi.create({ name: 'test' });
     const invitation = await invitationApi.create({


### PR DESCRIPTION
## Summary
- add missing scenario for accepting invitation without user ID

## Testing
- `pnpm ci:lint` *(fails: lint errors in other packages)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models test failure)*

------
https://chatgpt.com/codex/tasks/task_e_684f431ac8b0832fb78b5ce23e99d62e