### PR TITLE
Add branding cleanup test

### DIFF
--- a/packages/integration-tests/src/tests/console/sso-branding-cleanup.test.ts
+++ b/packages/integration-tests/src/tests/console/sso-branding-cleanup.test.ts
@@ -52,4 +52,25 @@ describe('enterprise sso branding cleanup', () => {
     const body = JSON.parse(patchRequest.postData() ?? '{}');
     expect(body).not.toHaveProperty('branding');
   });
+
+  it('should keep non-empty branding fields in patch request', async () => {
+    const patchRequestPromise = page.waitForRequest(
+      (request) =>
+        request.method() === 'PATCH' &&
+        request.url().includes(`/api/sso-connectors/${connectorId}`)
+    );
+
+    await expect(page).toFillForm('form', {
+      'branding.displayName': 'Updated name',
+      'branding.logo': '',
+      'branding.darkLogo': '',
+    });
+
+    await expectToSaveChanges(page);
+    await waitForToast(page, { text: 'Saved' });
+
+    const patchRequest = await patchRequestPromise;
+    const body = JSON.parse(patchRequest.postData() ?? '{}');
+    expect(body.branding).toEqual({ displayName: 'Updated name' });
+  });
 });


### PR DESCRIPTION
## Summary
- verify SSO branding cleanup covers partial empty values

## Testing
- `pnpm ci:lint` *(fails: Unsafe construction in connector-alipay-web)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models tests)*

------
https://chatgpt.com/codex/tasks/task_e_684f43160080832fbf470f8ca830dcd0