### PR TITLE
Simplify resource scope lookup logic

### DIFF
--- a/docs-ref/resource-scopes-refactor.md
+++ b/docs-ref/resource-scopes-refactor.md
@@ -5,7 +5,8 @@
 - `packages/core/src/oidc/resource.test.ts`
 
 **Key changes**
-- Extracted `findReservedResourceScopes`, `findOrganizationResourceScopes`, and `findDefaultResourceScopes` from `findResourceScopes`.
+- Consolidated subject lookup logic into `findSubjectResourceScopes` to remove duplication.
+- Replaced the switch statement in `findReservedResourceScopes` with a mapping for easier extension.
 - Added tests covering user priority over application scopes and the organization scenario.
 
 **New dependencies / environment variables**


### PR DESCRIPTION
## Summary
- use mapping for reserved scope resolvers
- consolidate default scope discovery into `findSubjectResourceScopes`
- update documentation for new helper

## Testing
- `pnpm ci:lint` *(fails: connector-alipay-web issues)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models and connector-aliyun-dm)*

------
https://chatgpt.com/codex/tasks/task_e_684f43120e30832f9a5ef9fd39ac23ec