### PR TITLE
Fix connector identifier validation

### DIFF
--- a/packages/core/src/routes/interaction/utils/sign-in-experience-validation.ts
+++ b/packages/core/src/routes/interaction/utils/sign-in-experience-validation.ts
@@ -36,6 +36,11 @@ export const verifyIdentifierSettings = (
 ) => {
   const { signIn, signUp } = signInExperience;
 
+  // Connector identifiers are validated by connector-specific logic
+  if ('connectorId' in identifier) {
+    return;
+  }
+
   // Username Password Identifier
   if ('username' in identifier) {
     assertThat(
@@ -45,12 +50,6 @@ export const verifyIdentifierSettings = (
       forbiddenIdentifierError()
     );
 
-    return;
-  }
-
-  // Social Identifier
-  // Connector related identifiers are validated by each connector implementation
-  if ('connectorId' in identifier) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- skip generic validation early for connector-based identifiers

## Testing
- `pnpm ci:lint` *(fails: unsafe call errors in connector packages)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: tests not found for cloud models)*

------
https://chatgpt.com/codex/tasks/task_e_684f430de7d0832f81c4eaf3e46b635f