### PR TITLE
Move social & webauthn helpers

### DIFF
--- a/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
@@ -96,16 +96,9 @@ export class WebAuthnVerification implements MfaVerificationRecord<VerificationT
    * This method is used to generate the WebAuthn registration options for the user.
    * The WebAuthn registration options is used to register a new WebAuthn credential for the user.
    *
- <<<<<<< codex/crear-módulo-compartido-webauthn
-   * Refers to the {@link generateWebAuthnRegistrationOptions} function in the
-   * `utils/webauthn-shared.ts` file. Keep it as the single source of truth for
-   * generating the WebAuthn registration options.
- =======
-   * Refers to the {@link generateWebAuthnRegistrationOptions} function in
-   * `interaction/utils/webauthn-options.ts` file.
-   * Keep it as the single source of truth for generating the WebAuthn registration options.
-   * TODO: Consider relocating the function under a shared folder
- >>>>>>> master
+  * Refers to the {@link generateWebAuthnRegistrationOptions} function in the
+  * `utils/webauthn-shared.ts` file. Keep it as the single source of truth for
+  * generating the WebAuthn registration options.
    */
   async generateWebAuthnRegistrationOptions(rpId: string): Promise<WebAuthnRegistrationOptions> {
     const user = await this.findUser();
@@ -171,16 +164,9 @@ export class WebAuthnVerification implements MfaVerificationRecord<VerificationT
    * This method is used to generate the WebAuthn authentication options for the user.
    * The WebAuthn authentication options is used to authenticate the user using existing WebAuthn credentials.
    *
- <<<<<<< codex/crear-módulo-compartido-webauthn
-   * Refers to the {@link generateWebAuthnAuthenticationOptions} function in the
-   * `utils/webauthn-shared.ts` file. Keep it as the single source of truth for
-   * generating the WebAuthn authentication options.
- =======
-   * Refers to the {@link generateWebAuthnAuthenticationOptions} function in
-   * `interaction/utils/webauthn-options.ts` file.
-   * Keep it as the single source of truth for generating the WebAuthn authentication options.
-   * TODO: Consider relocating the function under a shared folder
- >>>>>>> master
+  * Refers to the {@link generateWebAuthnAuthenticationOptions} function in the
+  * `utils/webauthn-shared.ts` file. Keep it as the single source of truth for
+  * generating the WebAuthn authentication options.
    *
    * @throws {RequestError} with status 400, if no WebAuthn credentials are found for the user.
    */

--- a/packages/core/src/routes/interaction/utils/webauthn.test.ts
+++ b/packages/core/src/routes/interaction/utils/webauthn.test.ts
@@ -32,17 +32,14 @@ const {
     .mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 1 } }),
 }));
 
-const { generateWebAuthnRegistrationOptions, generateWebAuthnAuthenticationOptions } =
- <<<<<<< codex/crear-módulo-compartido-webauthn
-  await import('../../../utils/webauthn-shared.js');
-const { verifyWebAuthnRegistration, verifyWebAuthnAuthentication } = await import('./webauthn.js');
- =======
-  await import('./webauthn-options.js');
+const {
+  generateWebAuthnRegistrationOptions,
+  generateWebAuthnAuthenticationOptions,
+} = await import('../../../utils/webauthn-shared.js');
 const {
   verifyWebAuthnRegistration,
   verifyWebAuthnAuthentication,
 } = await import('../experience/utils/verification/webauthn.js');
- >>>>>>> master
 
 const rpId = 'logto.io';
 const origin = 'https://logto.io';


### PR DESCRIPTION
## Summary
- move social verification helpers to shared utility
- relocate WebAuthn docs markers and cleanup
- fix test imports for webauthn utilities

## Testing
- `pnpm ci:lint` *(fails: connector-alipay-web lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models and connectors tests)*

------
https://chatgpt.com/codex/tasks/task_e_684f4305ed84832fb95ab7714c043472