### PR TITLE
Fix organization invitation error localization

### DIFF
--- a/packages/core/src/libraries/organization-invitation.ts
+++ b/packages/core/src/libraries/organization-invitation.ts
@@ -200,7 +200,11 @@ export class OrganizationInvitationLibrary {
           break;
         }
         default: {
-          throw new TypeError(`The status "${status}" is not supported.`);
+          throw new RequestError({
+            status: 422,
+            code: 'organization_invitation.unsupported_status',
+            data: { status },
+          });
         }
       }
 

--- a/packages/core/src/routes/organization-invitation/index.ts
+++ b/packages/core/src/routes/organization-invitation/index.ts
@@ -75,10 +75,8 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
 
       assertThat(
         body.expiresAt > Date.now(),
-        new RequestError({
-          code: 'organization_invitation.expires_at_future_required',
-          status: 400,
-        })
+        'organization_invitation.expires_at_future_required',
+        400
       );
 
       ctx.body = await organizationInvitations.insert(body, messagePayload);
@@ -146,10 +144,8 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
 
       assertThat(
         acceptedUserId,
-        new RequestError({
-          status: 422,
-          code: 'organization_invitation.accepted_user_id_required',
-        })
+        'organization_invitation.accepted_user_id_required',
+        422
       );
 
       const result = await organizationInvitations.updateStatus(id, status, acceptedUserId);

--- a/packages/phrases/src/locales/ar/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/ar/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/de/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/de/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/en/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/en/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/es/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/es/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'El usuario que acepta debe tener el mismo correo electrónico que el invitado.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/fr/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/fr/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/it/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/it/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/ja/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/ja/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/ko/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/ko/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/pl-pl/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/pt-br/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/pt-br/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/pt-pt/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/ru/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/ru/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/tr-tr/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/zh-cn/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/zh-hk/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);

--- a/packages/phrases/src/locales/zh-tw/errors/organization-invitation.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/organization-invitation.ts
@@ -4,6 +4,7 @@ const organization_invitation = {
   accepted_user_email_mismatch: 'The accepted user must have the same email as the invitee.',
   accepted_user_id_required: 'The `acceptedUserId` is required when accepting an invitation.',
   expires_at_future_required: 'The value of `expiresAt` must be in the future.',
+  unsupported_status: 'Unsupported status: {{status}}.',
 };
 
 export default Object.freeze(organization_invitation);


### PR DESCRIPTION
## Summary
- throw localized RequestError in organization-invitation library
- simplify asserts in organization-invitation routes
- add `unsupported_status` translation in all locales

## Testing
- `pnpm ci:lint` *(fails: connector packages lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models and connector tests)*

------
https://chatgpt.com/codex/tasks/task_e_684f42f33820832fa9033fd9f79fd9cd