### PR TITLE
Add SMSAero connector tests

### DIFF
--- a/docs-ref/smsaero-connector-tests.md
+++ b/docs-ref/smsaero-connector-tests.md
@@ -5,7 +5,11 @@
 - `packages/connectors/connector-smsaero/src/mock.ts`
 
 **Key changes**
-- Extended unit tests to cover error responses and invalid configurations.
+- Added unit tests covering:
+  - successful message delivery with stored and input configuration
+  - missing template handling
+  - service error responses and invalid response bodies
+  - invalid configuration passed directly or returned from `getConfig`
 - Mocked network requests with `nock` and simulated `HTTPError` to exercise all branches.
 
 **New dependencies / environment variables**

--- a/packages/connectors/connector-smsaero/src/index.test.ts
+++ b/packages/connectors/connector-smsaero/src/index.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import { ConnectorError, ConnectorErrorCodes, TemplateType } from '@logto/connector-kit';
 import { got, HTTPError, type PlainResponse } from 'got';
 import nock from 'nock';
@@ -146,6 +147,20 @@ describe('SMSAero SMS connector', () => {
         },
         invalidConfig
       )
+    ).rejects.toMatchObject({ code: ConnectorErrorCodes.InvalidConfig });
+  });
+
+  it('throws InvalidConfig when fetched config is invalid', async () => {
+    const invalidConfig: SmsAeroConfig = { ...mockedConfig, email: 'invalid-email' };
+    const invalidGetConfig = vi.fn().mockResolvedValue(invalidConfig);
+    const connector = await createConnector({ getConfig: invalidGetConfig });
+
+    await expect(
+      connector.sendMessage({
+        to: '+1234567890',
+        type: TemplateType.Generic,
+        payload: { code: '1234' },
+      })
     ).rejects.toMatchObject({ code: ConnectorErrorCodes.InvalidConfig });
   });
 });


### PR DESCRIPTION
## Summary
- extend SMSAero connector unit tests
- document test cases

## Testing
- `pnpm ci:lint` *(fails: connector-alipay-native lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: cloud-models and other packages test errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f42eef91c832fb571612afa4332ed