### PR TITLE
Update setup script env validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ ADMIN_ENDPOINT=http://localhost:3002
 
 A helper script is available to install dependencies and launch the development
 server. It will download Node.js `22.14.0` locally if needed and prepare pnpm.
+The script loads the `.env` file and verifies that the following variables are
+set: `MONGODB_URI`, `OPENSEARCH_URL`, `REDIS_URL`, `ENDPOINT`, and
+`ADMIN_ENDPOINT`. If any variable is missing, it exits with an error listing the
+missing names.
 
 ```bash
 ./run/setup.sh

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -3,6 +3,27 @@ set -euo pipefail
 
 REQUIRED_NODE_VERSION="22.14.0"
 NODE_DIR="$(dirname "$0")/node"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [[ -f "$ROOT_DIR/.env" ]]; then
+  echo "Loading environment variables from $ROOT_DIR/.env"
+  set -a
+  # shellcheck disable=SC1090
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+required_vars=(MONGODB_URI OPENSEARCH_URL REDIS_URL ENDPOINT ADMIN_ENDPOINT)
+missing=()
+for var in "${required_vars[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    missing+=("$var")
+  fi
+done
+if (( ${#missing[@]} )); then
+  echo "Missing required environment variables: ${missing[*]}" >&2
+  exit 1
+fi
 
 version_ge() {
   [ "$(printf '%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]


### PR DESCRIPTION
## Summary
- load `.env` in `run/setup.sh`
- validate required variables and exit when missing
- explain new behaviour in README

## Testing
- `pnpm ci:lint` *(fails: connector package lint errors)*
- `pnpm ci:stylelint`
- `pnpm ci:test` *(fails: connector package tests)*

------
https://chatgpt.com/codex/tasks/task_e_685025c68330832f886ac1f2a627e700